### PR TITLE
feat: process injection via LiveServerlessMixin

### DIFF
--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -149,6 +149,20 @@ FLASH_CPU_LB_IMAGE = os.environ.get(
     f"runpod/flash-lb-cpu:py{DEFAULT_PYTHON_VERSION}-{_RESOLVED_TAG}",
 )
 
+# Base images for process injection (no flash-worker baked in)
+FLASH_GPU_BASE_IMAGE = os.environ.get(
+    "FLASH_GPU_BASE_IMAGE", "pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime"
+)
+FLASH_CPU_BASE_IMAGE = os.environ.get("FLASH_CPU_BASE_IMAGE", "python:3.11-slim")
+
+# Worker tarball for process injection
+FLASH_WORKER_VERSION = os.environ.get("FLASH_WORKER_VERSION", "1.1.1")
+FLASH_WORKER_TARBALL_URL_TEMPLATE = os.environ.get(
+    "FLASH_WORKER_TARBALL_URL",
+    "https://github.com/runpod/flash-worker/releases/download/"
+    "v{version}/flash-worker-v{version}-py3.11-linux-x86_64.tar.gz",
+)
+
 # Worker configuration defaults
 DEFAULT_WORKERS_MIN = 0
 DEFAULT_WORKERS_MAX = 1

--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -159,7 +159,7 @@ FLASH_CPU_BASE_IMAGE = os.environ.get("FLASH_CPU_BASE_IMAGE", "python:3.11-slim"
 FLASH_WORKER_VERSION = os.environ.get("FLASH_WORKER_VERSION", "1.1.1")
 FLASH_WORKER_TARBALL_URL_TEMPLATE = os.environ.get(
     "FLASH_WORKER_TARBALL_URL",
-    "https://github.com/runpod/flash-worker/releases/download/"
+    "https://github.com/runpod-workers/flash/releases/download/"
     "v{version}/flash-worker-v{version}-py3.11-linux-x86_64.tar.gz",
 )
 

--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -119,6 +119,20 @@ FLASH_CPU_LB_IMAGE = os.environ.get(
     f"runpod/flash-lb-cpu:py{DEFAULT_PYTHON_VERSION}-{FLASH_IMAGE_TAG}",
 )
 
+# Base images for process injection (no flash-worker baked in)
+FLASH_GPU_BASE_IMAGE = os.environ.get(
+    "FLASH_GPU_BASE_IMAGE", "pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime"
+)
+FLASH_CPU_BASE_IMAGE = os.environ.get("FLASH_CPU_BASE_IMAGE", "python:3.11-slim")
+
+# Worker tarball for process injection
+FLASH_WORKER_VERSION = os.environ.get("FLASH_WORKER_VERSION", "1.1.1")
+FLASH_WORKER_TARBALL_URL_TEMPLATE = os.environ.get(
+    "FLASH_WORKER_TARBALL_URL",
+    "https://github.com/runpod/flash-worker/releases/download/"
+    "v{version}/flash-worker-v{version}-py3.11-linux-x86_64.tar.gz",
+)
+
 # Worker configuration defaults
 DEFAULT_WORKERS_MIN = 0
 DEFAULT_WORKERS_MAX = 1

--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -129,7 +129,7 @@ FLASH_CPU_BASE_IMAGE = os.environ.get("FLASH_CPU_BASE_IMAGE", "python:3.11-slim"
 FLASH_WORKER_VERSION = os.environ.get("FLASH_WORKER_VERSION", "1.1.1")
 FLASH_WORKER_TARBALL_URL_TEMPLATE = os.environ.get(
     "FLASH_WORKER_TARBALL_URL",
-    "https://github.com/runpod/flash-worker/releases/download/"
+    "https://github.com/runpod-workers/flash/releases/download/"
     "v{version}/flash-worker-v{version}-py3.11-linux-x86_64.tar.gz",
 )
 

--- a/src/runpod_flash/core/resources/injection.py
+++ b/src/runpod_flash/core/resources/injection.py
@@ -39,7 +39,12 @@ def build_injection_cmd(
         "else "
         "mkdir -p $FW_DIR; "
         f'DL_URL="{tarball_url}"; '
-        '(command -v curl >/dev/null 2>&1 && curl -sSL "$DL_URL" || wget -qO- "$DL_URL") '
+        "dl() { "
+        '(command -v curl >/dev/null 2>&1 && curl -sSL "$1" || '
+        'command -v wget >/dev/null 2>&1 && wget -qO- "$1" || '
+        'python3 -c "import urllib.request,sys;sys.stdout.buffer.write(urllib.request.urlopen(sys.argv[1]).read())" "$1"); '
+        "}; "
+        'dl "$DL_URL" '
         "| tar xz -C $FW_DIR --strip-components=1; "
         # Cache to network volume if available
         "if [ -d /runpod-volume ]; then "

--- a/src/runpod_flash/core/resources/injection.py
+++ b/src/runpod_flash/core/resources/injection.py
@@ -1,0 +1,49 @@
+"""Process injection utilities for flash-worker tarball delivery."""
+
+from .constants import FLASH_WORKER_TARBALL_URL_TEMPLATE, FLASH_WORKER_VERSION
+
+
+def build_injection_cmd(
+    worker_version: str = FLASH_WORKER_VERSION,
+    tarball_url: str | None = None,
+) -> str:
+    """Build the dockerArgs command that downloads, extracts, and runs flash-worker.
+
+    Supports remote URLs (curl/wget) and local file paths (file://) for testing.
+    Includes version-based caching to skip re-extraction on warm workers.
+    Network volume caching stores extracted tarball at /runpod-volume/.flash-worker/v{version}.
+    """
+    if tarball_url is None:
+        tarball_url = FLASH_WORKER_TARBALL_URL_TEMPLATE.format(version=worker_version)
+
+    if tarball_url.startswith("file://"):
+        local_path = tarball_url[7:]
+        return (
+            "bash -c '"
+            "set -e; FW_DIR=/opt/flash-worker; "
+            "mkdir -p $FW_DIR; "
+            f"tar xzf {local_path} -C $FW_DIR --strip-components=1; "
+            "exec $FW_DIR/bootstrap.sh'"
+        )
+
+    return (
+        "bash -c '"
+        f"set -e; FW_DIR=/opt/flash-worker; FW_VER={worker_version}; "
+        # Network volume cache check
+        'NV_CACHE="/runpod-volume/.flash-worker/v$FW_VER"; '
+        'if [ -d "$NV_CACHE" ] && [ -f "$NV_CACHE/.version" ]; then '
+        'cp -r "$NV_CACHE" "$FW_DIR"; '
+        # Local cache check (container disk persistence between restarts)
+        'elif [ -f "$FW_DIR/.version" ] && [ "$(cat $FW_DIR/.version)" = "$FW_VER" ]; then '
+        "true; "
+        "else "
+        "mkdir -p $FW_DIR; "
+        f'DL_URL="{tarball_url}"; '
+        '(command -v curl >/dev/null 2>&1 && curl -sSL "$DL_URL" || wget -qO- "$DL_URL") '
+        "| tar xz -C $FW_DIR --strip-components=1; "
+        # Cache to network volume if available
+        "if [ -d /runpod-volume ]; then "
+        'mkdir -p "$NV_CACHE" && cp -r "$FW_DIR"/* "$NV_CACHE/" 2>/dev/null || true; fi; '
+        "fi; "
+        "exec $FW_DIR/bootstrap.sh'"
+    )

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -7,16 +7,24 @@ from .constants import (
     DEFAULT_PYTHON_VERSION,
     get_image_name,
 )
+from .injection import build_injection_cmd
 from .load_balancer_sls_resource import (
     CpuLoadBalancerSlsResource,
     LoadBalancerSlsResource,
 )
 from .serverless import ServerlessEndpoint
 from .serverless_cpu import CpuServerlessEndpoint
+from .template import PodTemplate
 
 
 class LiveServerlessMixin:
-    """Common mixin for live serverless endpoints that locks the image."""
+    """Configures process injection via dockerArgs for any base image.
+
+    Sets a default base image (user can override via imageName) and generates
+    dockerArgs to download, extract, and run the flash-worker tarball at container
+    start time. QB vs LB mode is determined by FLASH_ENDPOINT_TYPE env var at
+    runtime, not by the Docker image.
+    """
 
     _image_type: ClassVar[str] = (
         ""  # override in subclasses: 'gpu', 'cpu', 'lb', 'lb-cpu'
@@ -34,6 +42,18 @@ class LiveServerlessMixin:
     @imageName.setter
     def imageName(self, value):
         pass
+
+    def _create_new_template(self) -> PodTemplate:
+        """Create template with dockerArgs for process injection."""
+        template = super()._create_new_template()  # type: ignore[misc]
+        template.dockerArgs = build_injection_cmd()
+        return template
+
+    def _configure_existing_template(self) -> None:
+        """Configure existing template, adding dockerArgs for injection if not user-set."""
+        super()._configure_existing_template()  # type: ignore[misc]
+        if self.template is not None and not self.template.dockerArgs:  # type: ignore[attr-defined]
+            self.template.dockerArgs = build_injection_cmd()  # type: ignore[attr-defined]
 
 
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -1,11 +1,10 @@
-# Ship serverless code as you write it. No builds, no deploys -- just run.
-from typing import ClassVar
-
+# Ship serverless code as you write it. No builds, no deploys — just run.
 from pydantic import model_validator
 
 from .constants import (
-    DEFAULT_PYTHON_VERSION,
+    GPU_BASE_IMAGE_PYTHON_VERSION,
     get_image_name,
+    local_python_version,
 )
 from .injection import build_injection_cmd
 from .load_balancer_sls_resource import (
@@ -26,23 +25,6 @@ class LiveServerlessMixin:
     runtime, not by the Docker image.
     """
 
-    _image_type: ClassVar[str] = (
-        ""  # override in subclasses: 'gpu', 'cpu', 'lb', 'lb-cpu'
-    )
-
-    @property
-    def _live_image(self) -> str:
-        python_version = getattr(self, "python_version", None) or DEFAULT_PYTHON_VERSION
-        return get_image_name(self._image_type, python_version)
-
-    @property
-    def imageName(self):
-        return self._live_image
-
-    @imageName.setter
-    def imageName(self, value):
-        pass
-
     def _create_new_template(self) -> PodTemplate:
         """Create template with dockerArgs for process injection."""
         template = super()._create_new_template()  # type: ignore[misc]
@@ -59,54 +41,50 @@ class LiveServerlessMixin:
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
     """GPU-only live serverless endpoint."""
 
-    _image_type: ClassVar[str] = "gpu"
-
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
         """Set default GPU image for Live Serverless."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("gpu", python_version)
+        if "imageName" not in data:
+            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
+            data["imageName"] = get_image_name("gpu", python_version)
         return data
 
 
 class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
     """CPU-only live serverless endpoint with automatic disk sizing."""
 
-    _image_type: ClassVar[str] = "cpu"
-
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
         """Set default CPU image for Live Serverless."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("cpu", python_version)
+        if "imageName" not in data:
+            python_version = data.get("python_version") or local_python_version()
+            data["imageName"] = get_image_name("cpu", python_version)
         return data
 
 
 class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
     """Live load-balanced endpoint."""
 
-    _image_type: ClassVar[str] = "lb"
-
     @model_validator(mode="before")
     @classmethod
     def set_live_lb_template(cls, data: dict):
         """Set default image for Live Load-Balanced endpoint."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("lb", python_version)
+        if "imageName" not in data:
+            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
+            data["imageName"] = get_image_name("lb", python_version)
         return data
 
 
 class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
     """CPU-only live load-balanced endpoint."""
 
-    _image_type: ClassVar[str] = "lb-cpu"
-
     @model_validator(mode="before")
     @classmethod
     def set_live_cpu_lb_template(cls, data: dict):
         """Set default CPU image for Live Load-Balanced endpoint."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("lb-cpu", python_version)
+        if "imageName" not in data:
+            python_version = data.get("python_version") or local_python_version()
+            data["imageName"] = get_image_name("lb-cpu", python_version)
         return data

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -7,12 +7,14 @@ from .constants import (
     DEFAULT_PYTHON_VERSION,
     get_image_name,
 )
+from .injection import build_injection_cmd
 from .load_balancer_sls_resource import (
     CpuLoadBalancerSlsResource,
     LoadBalancerSlsResource,
 )
 from .serverless import ServerlessEndpoint
 from .serverless_cpu import CpuServerlessEndpoint
+from .template import PodTemplate
 
 
 class LiveServerlessMixin:
@@ -27,6 +29,12 @@ class LiveServerlessMixin:
     concrete subclass (see ``_apply_default_live_image``); reads and writes of
     ``imageName`` go through the normal Pydantic field machinery so model
     serialization, drift detection, and ``setattr`` all stay consistent.
+    """Configures process injection via dockerArgs for any base image.
+
+    Sets a default base image (user can override via imageName) and generates
+    dockerArgs to download, extract, and run the flash-worker tarball at container
+    start time. QB vs LB mode is determined by FLASH_ENDPOINT_TYPE env var at
+    runtime, not by the Docker image.
     """
 
     _image_type: ClassVar[str] = (
@@ -52,6 +60,18 @@ def _apply_default_live_image(data: Any, image_type: str):
         python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
         data["imageName"] = get_image_name(image_type, python_version)
     return data
+
+    def _create_new_template(self) -> PodTemplate:
+        """Create template with dockerArgs for process injection."""
+        template = super()._create_new_template()  # type: ignore[misc]
+        template.dockerArgs = build_injection_cmd()
+        return template
+
+    def _configure_existing_template(self) -> None:
+        """Configure existing template, adding dockerArgs for injection if not user-set."""
+        super()._configure_existing_template()  # type: ignore[misc]
+        if self.template is not None and not self.template.dockerArgs:  # type: ignore[attr-defined]
+            self.template.dockerArgs = build_injection_cmd()  # type: ignore[attr-defined]
 
 
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -1,11 +1,13 @@
 # Ship serverless code as you write it. No builds, no deploys -- just run.
 from typing import Any, ClassVar
 
+# Ship serverless code as you write it. No builds, no deploys — just run.
 from pydantic import model_validator
 
 from .constants import (
-    DEFAULT_PYTHON_VERSION,
+    GPU_BASE_IMAGE_PYTHON_VERSION,
     get_image_name,
+    local_python_version,
 )
 from .injection import build_injection_cmd
 from .load_balancer_sls_resource import (
@@ -77,46 +79,58 @@ def _apply_default_live_image(data: Any, image_type: str):
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
     """GPU-only live serverless endpoint."""
 
-    _image_type: ClassVar[str] = "gpu"
-
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
         """Default to the GPU Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "gpu")
+        """Set default GPU image for Live Serverless."""
+        if "imageName" not in data:
+            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
+            data["imageName"] = get_image_name("gpu", python_version)
+        return data
 
 
 class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
     """CPU-only live serverless endpoint with automatic disk sizing."""
-
-    _image_type: ClassVar[str] = "cpu"
 
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
         """Default to the CPU Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "cpu")
+        """Set default CPU image for Live Serverless."""
+        if "imageName" not in data:
+            python_version = data.get("python_version") or local_python_version()
+            data["imageName"] = get_image_name("cpu", python_version)
+        return data
 
 
 class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
     """Live load-balanced endpoint."""
-
-    _image_type: ClassVar[str] = "lb"
 
     @model_validator(mode="before")
     @classmethod
     def set_live_lb_template(cls, data: dict):
         """Default to the LB Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "lb")
+        """Set default image for Live Load-Balanced endpoint."""
+        if "imageName" not in data:
+            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
+            data["imageName"] = get_image_name("lb", python_version)
+        return data
 
 
 class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
     """CPU-only live load-balanced endpoint."""
-
-    _image_type: ClassVar[str] = "lb-cpu"
 
     @model_validator(mode="before")
     @classmethod
     def set_live_cpu_lb_template(cls, data: dict):
         """Default to the CPU LB Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "lb-cpu")
+        """Set default CPU image for Live Load-Balanced endpoint."""
+        if "imageName" not in data:
+            python_version = data.get("python_version") or local_python_version()
+            data["imageName"] = get_image_name("lb-cpu", python_version)
+        return data

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -1,14 +1,9 @@
 # Ship serverless code as you write it. No builds, no deploys -- just run.
-from typing import Any, ClassVar
+from typing import Any
 
-# Ship serverless code as you write it. No builds, no deploys — just run.
 from pydantic import model_validator
 
-from .constants import (
-    GPU_BASE_IMAGE_PYTHON_VERSION,
-    get_image_name,
-    local_python_version,
-)
+from .constants import DEFAULT_PYTHON_VERSION, get_image_name
 from .injection import build_injection_cmd
 from .load_balancer_sls_resource import (
     CpuLoadBalancerSlsResource,
@@ -22,31 +17,30 @@ from .template import PodTemplate
 class LiveServerlessMixin:
     """Common mixin for live serverless endpoints.
 
-    Treats the Flash runtime image as a *default*: if the caller passes an
-    ``imageName`` (e.g. via ``Endpoint(image=...)`` in client mode), that
-    value wins. Otherwise the Flash runtime image for this resource type is
-    used so decorator-mode workloads continue to deploy the Flash wrapper.
+    Configures process injection via ``dockerArgs`` for any base image, and
+    treats the Flash runtime image as a *default*: if the caller passes an
+    ``imageName`` (e.g. via ``Endpoint(image=...)`` in client mode), that value
+    wins. Otherwise the Flash runtime image for this resource type is applied by
+    the ``@model_validator(mode="before")`` on each concrete subclass (see
+    ``_apply_default_live_image``), so decorator-mode workloads continue to
+    deploy the Flash wrapper.
 
-    The default is applied via the ``@model_validator(mode="before")`` on each
-    concrete subclass (see ``_apply_default_live_image``); reads and writes of
-    ``imageName`` go through the normal Pydantic field machinery so model
-    serialization, drift detection, and ``setattr`` all stay consistent.
-    """Configures process injection via dockerArgs for any base image.
-
-    Sets a default base image (user can override via imageName) and generates
-    dockerArgs to download, extract, and run the flash-worker tarball at container
-    start time. QB vs LB mode is determined by FLASH_ENDPOINT_TYPE env var at
-    runtime, not by the Docker image.
+    The injection ``dockerArgs`` download, extract, and run the flash-worker
+    tarball at container start; QB vs LB mode is determined by the
+    ``FLASH_ENDPOINT_TYPE`` env var at runtime, not by the Docker image.
     """
 
-    _image_type: ClassVar[str] = (
-        ""  # override in subclasses: 'gpu', 'cpu', 'lb', 'lb-cpu'
-    )
+    def _create_new_template(self) -> PodTemplate:
+        """Create template with dockerArgs for process injection."""
+        template = super()._create_new_template()  # type: ignore[misc]
+        template.dockerArgs = build_injection_cmd()
+        return template
 
-    @property
-    def _live_image(self) -> str:
-        python_version = getattr(self, "python_version", None) or DEFAULT_PYTHON_VERSION
-        return get_image_name(self._image_type, python_version)
+    def _configure_existing_template(self) -> None:
+        """Configure existing template, adding dockerArgs for injection if not user-set."""
+        super()._configure_existing_template()  # type: ignore[misc]
+        if self.template is not None and not self.template.dockerArgs:  # type: ignore[attr-defined]
+            self.template.dockerArgs = build_injection_cmd()  # type: ignore[attr-defined]
 
 
 def _apply_default_live_image(data: Any, image_type: str):
@@ -63,18 +57,6 @@ def _apply_default_live_image(data: Any, image_type: str):
         data["imageName"] = get_image_name(image_type, python_version)
     return data
 
-    def _create_new_template(self) -> PodTemplate:
-        """Create template with dockerArgs for process injection."""
-        template = super()._create_new_template()  # type: ignore[misc]
-        template.dockerArgs = build_injection_cmd()
-        return template
-
-    def _configure_existing_template(self) -> None:
-        """Configure existing template, adding dockerArgs for injection if not user-set."""
-        super()._configure_existing_template()  # type: ignore[misc]
-        if self.template is not None and not self.template.dockerArgs:  # type: ignore[attr-defined]
-            self.template.dockerArgs = build_injection_cmd()  # type: ignore[attr-defined]
-
 
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
     """GPU-only live serverless endpoint."""
@@ -84,11 +66,6 @@ class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
     def set_live_serverless_template(cls, data: dict):
         """Default to the GPU Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "gpu")
-        """Set default GPU image for Live Serverless."""
-        if "imageName" not in data:
-            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
-            data["imageName"] = get_image_name("gpu", python_version)
-        return data
 
 
 class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
@@ -99,11 +76,6 @@ class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
     def set_live_serverless_template(cls, data: dict):
         """Default to the CPU Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "cpu")
-        """Set default CPU image for Live Serverless."""
-        if "imageName" not in data:
-            python_version = data.get("python_version") or local_python_version()
-            data["imageName"] = get_image_name("cpu", python_version)
-        return data
 
 
 class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
@@ -114,11 +86,6 @@ class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
     def set_live_lb_template(cls, data: dict):
         """Default to the LB Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "lb")
-        """Set default image for Live Load-Balanced endpoint."""
-        if "imageName" not in data:
-            python_version = data.get("python_version") or GPU_BASE_IMAGE_PYTHON_VERSION
-            data["imageName"] = get_image_name("lb", python_version)
-        return data
 
 
 class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
@@ -129,8 +96,3 @@ class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
     def set_live_cpu_lb_template(cls, data: dict):
         """Default to the CPU LB Flash runtime image when none is supplied."""
         return _apply_default_live_image(data, "lb-cpu")
-        """Set default CPU image for Live Load-Balanced endpoint."""
-        if "imageName" not in data:
-            python_version = data.get("python_version") or local_python_version()
-            data["imageName"] = get_image_name("lb-cpu", python_version)
-        return data

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -129,7 +129,7 @@ class TestCpuDiskSizingIntegration:
         # 2. CPU utilities calculate minimum disk size
         # 3. Template creation with auto-sizing
         # 4. Validation passes
-        assert live_serverless.imageName == "python:3.11-slim"
+        assert "runpod/flash-cpu:" in live_serverless.imageName
         assert live_serverless.instanceIds == [
             CpuInstanceType.CPU5C_1_2,
             CpuInstanceType.CPU5C_2_4,
@@ -254,8 +254,8 @@ class TestLiveServerlessImageDefaultsIntegration:
 
         # Verify different base images are used
         assert gpu_live.imageName != cpu_live.imageName
-        assert "pytorch" in gpu_live.imageName
-        assert "python" in cpu_live.imageName
+        assert "runpod/flash:" in gpu_live.imageName
+        assert "runpod/flash-cpu:" in cpu_live.imageName
 
         # Verify images can be overridden (BYOI)
         custom_gpu = LiveServerless(

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -129,7 +129,7 @@ class TestCpuDiskSizingIntegration:
         # 2. CPU utilities calculate minimum disk size
         # 3. Template creation with auto-sizing
         # 4. Validation passes
-        assert live_serverless.imageName == "python:3.12-slim"
+        assert live_serverless.imageName == "python:3.11-slim"
         assert live_serverless.instanceIds == [
             CpuInstanceType.CPU5C_1_2,
             CpuInstanceType.CPU5C_2_4,

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -125,11 +125,11 @@ class TestCpuDiskSizingIntegration:
         )
 
         # Verify integration:
-        # 1. Uses CPU image (locked)
+        # 1. Uses CPU base image (default)
         # 2. CPU utilities calculate minimum disk size
         # 3. Template creation with auto-sizing
         # 4. Validation passes
-        assert "flash-cpu:" in live_serverless.imageName
+        assert live_serverless.imageName == "python:3.12-slim"
         assert live_serverless.instanceIds == [
             CpuInstanceType.CPU5C_1_2,
             CpuInstanceType.CPU5C_2_4,
@@ -244,28 +244,24 @@ class TestCpuDiskSizingIntegration:
         assert "cpu5c-1-2: max 15GB" in error_msg
 
 
-class TestLiveServerlessImageLockingIntegration:
-    """Test image locking integration in live serverless variants."""
+class TestLiveServerlessImageDefaultsIntegration:
+    """Test image defaults in live serverless variants."""
 
-    def test_live_serverless_image_consistency(self):
-        """Test that LiveServerless variants maintain image consistency."""
+    def test_live_serverless_image_defaults(self):
+        """Test that LiveServerless variants use correct base images."""
         gpu_live = LiveServerless(name="gpu-live")
         cpu_live = CpuLiveServerless(name="cpu-live")
 
-        # Verify different images are used
+        # Verify different base images are used
         assert gpu_live.imageName != cpu_live.imageName
-        assert "flash:" in gpu_live.imageName
-        assert "flash-cpu:" in cpu_live.imageName
+        assert "pytorch" in gpu_live.imageName
+        assert "python" in cpu_live.imageName
 
-        # Verify images remain locked despite attempts to change
-        original_gpu_image = gpu_live.imageName
-        original_cpu_image = cpu_live.imageName
-
-        gpu_live.imageName = "custom/image:latest"
-        cpu_live.imageName = "custom/image:latest"
-
-        assert gpu_live.imageName == original_gpu_image
-        assert cpu_live.imageName == original_cpu_image
+        # Verify images can be overridden (BYOI)
+        custom_gpu = LiveServerless(
+            name="custom-gpu", imageName="nvidia/cuda:12.8.0-runtime"
+        )
+        assert custom_gpu.imageName == "nvidia/cuda:12.8.0-runtime"
 
     def test_live_serverless_template_integration(self):
         """Test live serverless template integration with disk sizing."""

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -125,11 +125,11 @@ class TestCpuDiskSizingIntegration:
         )
 
         # Verify integration:
-        # 1. Uses CPU image (locked)
+        # 1. Uses CPU base image (default)
         # 2. CPU utilities calculate minimum disk size
         # 3. Template creation with auto-sizing
         # 4. Validation passes
-        assert "flash-cpu:" in live_serverless.imageName
+        assert live_serverless.imageName == "python:3.12-slim"
         assert live_serverless.instanceIds == [
             CpuInstanceType.CPU5C_1_2,
             CpuInstanceType.CPU5C_2_4,
@@ -253,9 +253,18 @@ class TestLiveServerlessImageIntegration:
         cpu_live = CpuLiveServerless(name="cpu-live")
 
         # Verify different default images are used per resource type.
+class TestLiveServerlessImageDefaultsIntegration:
+    """Test image defaults in live serverless variants."""
+
+    def test_live_serverless_image_defaults(self):
+        """Test that LiveServerless variants use correct base images."""
+        gpu_live = LiveServerless(name="gpu-live")
+        cpu_live = CpuLiveServerless(name="cpu-live")
+
+        # Verify different base images are used
         assert gpu_live.imageName != cpu_live.imageName
-        assert "flash:" in gpu_live.imageName
-        assert "flash-cpu:" in cpu_live.imageName
+        assert "pytorch" in gpu_live.imageName
+        assert "python" in cpu_live.imageName
 
     def test_live_serverless_image_override_via_constructor(self):
         """Caller-supplied imageName overrides the Flash runtime default (AE-3153)."""
@@ -266,6 +275,11 @@ class TestLiveServerlessImageIntegration:
 
         assert gpu_live.imageName == "custom/image:latest"
         assert cpu_live.imageName == "custom/cpu-image:latest"
+        # Verify images can be overridden (BYOI)
+        custom_gpu = LiveServerless(
+            name="custom-gpu", imageName="nvidia/cuda:12.8.0-runtime"
+        )
+        assert custom_gpu.imageName == "nvidia/cuda:12.8.0-runtime"
 
     def test_live_serverless_template_integration(self):
         """Test live serverless template integration with disk sizing."""

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -129,7 +129,7 @@ class TestCpuDiskSizingIntegration:
         # 2. CPU utilities calculate minimum disk size
         # 3. Template creation with auto-sizing
         # 4. Validation passes
-        assert live_serverless.imageName == "python:3.11-slim"
+        assert "runpod/flash-cpu:" in live_serverless.imageName
         assert live_serverless.instanceIds == [
             CpuInstanceType.CPU5C_1_2,
             CpuInstanceType.CPU5C_2_4,
@@ -263,8 +263,8 @@ class TestLiveServerlessImageDefaultsIntegration:
 
         # Verify different base images are used
         assert gpu_live.imageName != cpu_live.imageName
-        assert "pytorch" in gpu_live.imageName
-        assert "python" in cpu_live.imageName
+        assert "runpod/flash:" in gpu_live.imageName
+        assert "runpod/flash-cpu:" in cpu_live.imageName
 
     def test_live_serverless_image_override_via_constructor(self):
         """Caller-supplied imageName overrides the Flash runtime default (AE-3153)."""

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -244,15 +244,6 @@ class TestCpuDiskSizingIntegration:
         assert "cpu5c-1-2: max 15GB" in error_msg
 
 
-class TestLiveServerlessImageIntegration:
-    """Test image default + override behavior in live serverless variants (AE-3153)."""
-
-    def test_live_serverless_image_consistency(self):
-        """LiveServerless variants default to distinct Flash runtime images."""
-        gpu_live = LiveServerless(name="gpu-live")
-        cpu_live = CpuLiveServerless(name="cpu-live")
-
-        # Verify different default images are used per resource type.
 class TestLiveServerlessImageDefaultsIntegration:
     """Test image defaults in live serverless variants."""
 

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -114,13 +114,13 @@ class TestRemoteWithLoadBalancerIntegration:
         # Verify resource is correctly configured
         # Note: name may have "-fb" appended by flash boot validator
         assert "test-live-api" in lb.name
-        assert "pytorch" in lb.imageName  # GPU base image
+        assert "runpod/flash-lb:" in lb.imageName  # GPU LB base image
         assert echo.__remote_config__["method"] == "POST"
 
     def test_live_load_balancer_default_image(self):
-        """Test that LiveLoadBalancer uses GPU base image by default."""
+        """Test that LiveLoadBalancer uses GPU LB base image by default."""
         lb = LiveLoadBalancer(name="test-api")
-        assert "pytorch" in lb.imageName
+        assert "runpod/flash-lb:" in lb.imageName
 
     def test_live_load_balancer_allows_custom_image(self):
         """Test that LiveLoadBalancer allows user to set custom image (BYOI)."""

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -112,23 +112,20 @@ class TestRemoteWithLoadBalancerIntegration:
             return {"echo": message}
 
         # Verify resource is correctly configured
-        assert lb.name == "test-live-api"
-        assert "flash-lb" in lb.imageName
+        # Note: name may have "-fb" appended by flash boot validator
+        assert "test-live-api" in lb.name
+        assert "pytorch" in lb.imageName  # GPU base image
         assert echo.__remote_config__["method"] == "POST"
 
-    def test_live_load_balancer_image_locked(self):
-        """Test that LiveLoadBalancer locks the image to Flash LB image."""
+    def test_live_load_balancer_default_image(self):
+        """Test that LiveLoadBalancer uses GPU base image by default."""
         lb = LiveLoadBalancer(name="test-api")
+        assert "pytorch" in lb.imageName
 
-        # Verify image is locked and cannot be overridden
-        original_image = lb.imageName
-        assert "flash-lb" in original_image
-
-        # Try to set a different image (should be ignored due to property)
-        lb.imageName = "custom-image:latest"
-
-        # Image should still be locked to Flash
-        assert lb.imageName == original_image
+    def test_live_load_balancer_allows_custom_image(self):
+        """Test that LiveLoadBalancer allows user to set custom image (BYOI)."""
+        lb = LiveLoadBalancer(name="test-api", imageName="custom-image:latest")
+        assert lb.imageName == "custom-image:latest"
 
     def test_load_balancer_vs_queue_based_endpoints(self):
         """Test that LB and QB endpoints have different characteristics."""
@@ -184,7 +181,7 @@ def get_status():
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            py_file = project_dir / "api_worker.py"
+            py_file = project_dir / "test_api.py"
             py_file.write_text(code)
 
             scanner = RuntimeScanner(project_dir)
@@ -199,7 +196,9 @@ def get_status():
             assert "LoadBalancerSlsResource" in resource_types
 
             # Verify resource configs were extracted
-            assert "test-api" in scanner.resource_types
-            assert scanner.resource_types["test-api"] == "LiveLoadBalancer"
-            assert "deployed-api" in scanner.resource_types
-            assert scanner.resource_types["deployed-api"] == "LoadBalancerSlsResource"
+            assert "test-api-fb" in scanner.resource_types
+            assert scanner.resource_types["test-api-fb"] == "LiveLoadBalancer"
+            assert "deployed-api-fb" in scanner.resource_types
+            assert (
+                scanner.resource_types["deployed-api-fb"] == "LoadBalancerSlsResource"
+            )

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -112,8 +112,9 @@ class TestRemoteWithLoadBalancerIntegration:
             return {"echo": message}
 
         # Verify resource is correctly configured
-        assert lb.name == "test-live-api"
-        assert "flash-lb" in lb.imageName
+        # Note: name may have "-fb" appended by flash boot validator
+        assert "test-live-api" in lb.name
+        assert "pytorch" in lb.imageName  # GPU base image
         assert echo.__remote_config__["method"] == "POST"
 
     def test_live_load_balancer_image_default_and_override(self):
@@ -131,6 +132,15 @@ class TestRemoteWithLoadBalancerIntegration:
         # Guard against a future regression where both paths collapse to the
         # same default (e.g. the override branch reverting to a no-op).
         assert default_lb.imageName != custom_lb.imageName
+    def test_live_load_balancer_default_image(self):
+        """Test that LiveLoadBalancer uses GPU base image by default."""
+        lb = LiveLoadBalancer(name="test-api")
+        assert "pytorch" in lb.imageName
+
+    def test_live_load_balancer_allows_custom_image(self):
+        """Test that LiveLoadBalancer allows user to set custom image (BYOI)."""
+        lb = LiveLoadBalancer(name="test-api", imageName="custom-image:latest")
+        assert lb.imageName == "custom-image:latest"
 
     def test_load_balancer_vs_queue_based_endpoints(self):
         """Test that LB and QB endpoints have different characteristics."""
@@ -186,7 +196,7 @@ def get_status():
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            py_file = project_dir / "api_worker.py"
+            py_file = project_dir / "test_api.py"
             py_file.write_text(code)
 
             scanner = RuntimeScanner(project_dir)
@@ -201,7 +211,9 @@ def get_status():
             assert "LoadBalancerSlsResource" in resource_types
 
             # Verify resource configs were extracted
-            assert "test-api" in scanner.resource_types
-            assert scanner.resource_types["test-api"] == "LiveLoadBalancer"
-            assert "deployed-api" in scanner.resource_types
-            assert scanner.resource_types["deployed-api"] == "LoadBalancerSlsResource"
+            assert "test-api-fb" in scanner.resource_types
+            assert scanner.resource_types["test-api-fb"] == "LiveLoadBalancer"
+            assert "deployed-api-fb" in scanner.resource_types
+            assert (
+                scanner.resource_types["deployed-api-fb"] == "LoadBalancerSlsResource"
+            )

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -114,7 +114,7 @@ class TestRemoteWithLoadBalancerIntegration:
         # Verify resource is correctly configured
         # Note: name may have "-fb" appended by flash boot validator
         assert "test-live-api" in lb.name
-        assert "pytorch" in lb.imageName  # GPU base image
+        assert "runpod/flash-lb:" in lb.imageName  # GPU LB base image
         assert echo.__remote_config__["method"] == "POST"
 
     def test_live_load_balancer_image_default_and_override(self):
@@ -133,9 +133,9 @@ class TestRemoteWithLoadBalancerIntegration:
         # same default (e.g. the override branch reverting to a no-op).
         assert default_lb.imageName != custom_lb.imageName
     def test_live_load_balancer_default_image(self):
-        """Test that LiveLoadBalancer uses GPU base image by default."""
+        """Test that LiveLoadBalancer uses GPU LB base image by default."""
         lb = LiveLoadBalancer(name="test-api")
-        assert "pytorch" in lb.imageName
+        assert "runpod/flash-lb:" in lb.imageName
 
     def test_live_load_balancer_allows_custom_image(self):
         """Test that LiveLoadBalancer allows user to set custom image (BYOI)."""

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -132,6 +132,7 @@ class TestRemoteWithLoadBalancerIntegration:
         # Guard against a future regression where both paths collapse to the
         # same default (e.g. the override branch reverting to a no-op).
         assert default_lb.imageName != custom_lb.imageName
+
     def test_live_load_balancer_default_image(self):
         """Test that LiveLoadBalancer uses GPU LB base image by default."""
         lb = LiveLoadBalancer(name="test-api")
@@ -170,50 +171,50 @@ class TestRemoteWithLoadBalancerIntegration:
         assert qb_func.__remote_config__["path"] is None
 
     def test_scanner_discovers_load_balancer_resources(self):
-        """Test that scanner can discover LiveLoadBalancer and LoadBalancerSlsResource."""
+        """Test that scanner discovers @Endpoint load-balanced route handlers."""
         from runpod_flash.cli.commands.build_utils.scanner import RuntimeScanner
         from pathlib import Path
         import tempfile
 
-        # Create temporary Python file with LoadBalancer resource
+        # Uses the current @Endpoint API (remote is deprecated). The worker file
+        # must NOT be named test_*.py — the scanner skips test files, so a
+        # test-prefixed fixture would yield zero discovered functions.
         code = """
-from runpod_flash import LiveLoadBalancer, LoadBalancerSlsResource, remote
+from runpod_flash.endpoint import Endpoint
+from runpod_flash.core.resources.gpu import GpuGroup
 
-# Test LiveLoadBalancer discovery
-api = LiveLoadBalancer(name="test-api")
+api = Endpoint(name="test-api", gpu=GpuGroup.AMPERE_16)
 
-@remote(api, method="POST", path="/api/process")
+@api.post("/api/process")
 async def process_data(x: int):
     return {"result": x}
 
-# Test LoadBalancerSlsResource discovery
-deployed = LoadBalancerSlsResource(name="deployed-api", imageName="test:latest")
+status_api = Endpoint(name="deployed-api", gpu=GpuGroup.AMPERE_16)
 
-@remote(deployed, method="GET", path="/api/status")
+@status_api.get("/api/status")
 def get_status():
     return {"status": "ok"}
 """
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            py_file = project_dir / "test_api.py"
+            py_file = project_dir / "worker_api.py"
             py_file.write_text(code)
 
             scanner = RuntimeScanner(project_dir)
             functions = scanner.discover_remote_functions()
 
-            # Verify both resources were discovered
+            # Both LB route handlers are discovered.
             assert len(functions) == 2
 
-            # Verify resource types are correctly identified
-            resource_types = {f.resource_type for f in functions}
-            assert "LiveLoadBalancer" in resource_types
-            assert "LoadBalancerSlsResource" in resource_types
+            # Endpoint(gpu=...) with route handlers resolves to LiveLoadBalancer.
+            assert {f.resource_type for f in functions} == {"LiveLoadBalancer"}
+            assert all(f.is_load_balanced for f in functions)
 
-            # Verify resource configs were extracted
-            assert "test-api-fb" in scanner.resource_types
-            assert scanner.resource_types["test-api-fb"] == "LiveLoadBalancer"
-            assert "deployed-api-fb" in scanner.resource_types
-            assert (
-                scanner.resource_types["deployed-api-fb"] == "LoadBalancerSlsResource"
-            )
+            # HTTP method and path are captured per route.
+            routes = {(f.http_method, f.http_path) for f in functions}
+            assert routes == {("POST", "/api/process"), ("GET", "/api/status")}
+
+            # Resource configs are tracked by name.
+            assert scanner.resource_types["test-api"] == "LiveLoadBalancer"
+            assert scanner.resource_types["deployed-api"] == "LiveLoadBalancer"

--- a/tests/unit/resources/test_injection.py
+++ b/tests/unit/resources/test_injection.py
@@ -12,7 +12,7 @@ class TestBuildInjectionCmd:
 
         assert cmd.startswith("bash -c '")
         assert "FW_VER=1.1.1" in cmd
-        assert "flash-worker/releases/download/v1.1.1/" in cmd
+        assert "runpod-workers/flash/releases/download/v1.1.1/" in cmd
         assert "bootstrap.sh'" in cmd
 
     def test_custom_tarball_url(self):
@@ -50,12 +50,13 @@ class TestBuildInjectionCmd:
         assert "/runpod-volume/.flash-worker/" in cmd
         assert "NV_CACHE" in cmd
 
-    def test_curl_wget_fallback(self):
-        """Test curl/wget fallback logic."""
+    def test_curl_wget_python_fallback(self):
+        """Test curl/wget/python3 fallback chain."""
         cmd = build_injection_cmd(worker_version="1.0.0")
 
         assert "curl -sSL" in cmd
         assert "wget -qO-" in cmd
+        assert "urllib.request" in cmd
 
     def test_default_uses_constants(self):
         """Test that calling with no args uses module-level constants."""

--- a/tests/unit/resources/test_injection.py
+++ b/tests/unit/resources/test_injection.py
@@ -1,0 +1,82 @@
+"""Unit tests for process injection utilities."""
+
+from runpod_flash.core.resources.injection import build_injection_cmd
+
+
+class TestBuildInjectionCmd:
+    """Test build_injection_cmd() output format."""
+
+    def test_default_remote_url(self):
+        """Test default remote URL generation."""
+        cmd = build_injection_cmd(worker_version="1.1.1")
+
+        assert cmd.startswith("bash -c '")
+        assert "FW_VER=1.1.1" in cmd
+        assert "flash-worker/releases/download/v1.1.1/" in cmd
+        assert "bootstrap.sh'" in cmd
+
+    def test_custom_tarball_url(self):
+        """Test custom tarball URL."""
+        url = "https://example.com/worker.tar.gz"
+        cmd = build_injection_cmd(worker_version="2.0.0", tarball_url=url)
+
+        assert "FW_VER=2.0.0" in cmd
+        assert url in cmd
+
+    def test_file_url_for_local_testing(self):
+        """Test file:// URL generates local extraction command."""
+        cmd = build_injection_cmd(
+            worker_version="1.0.0",
+            tarball_url="file:///tmp/flash-worker.tar.gz",
+        )
+
+        assert "tar xzf /tmp/flash-worker.tar.gz" in cmd
+        assert "curl" not in cmd
+        assert "wget" not in cmd
+        assert "bootstrap.sh'" in cmd
+
+    def test_version_caching_logic(self):
+        """Test that version-based cache check is included."""
+        cmd = build_injection_cmd(worker_version="1.1.1")
+
+        # Should check .version file
+        assert ".version" in cmd
+        assert "FW_VER" in cmd
+
+    def test_network_volume_caching(self):
+        """Test network volume cache path is included."""
+        cmd = build_injection_cmd(worker_version="1.1.1")
+
+        assert "/runpod-volume/.flash-worker/" in cmd
+        assert "NV_CACHE" in cmd
+
+    def test_curl_wget_fallback(self):
+        """Test curl/wget fallback logic."""
+        cmd = build_injection_cmd(worker_version="1.0.0")
+
+        assert "curl -sSL" in cmd
+        assert "wget -qO-" in cmd
+
+    def test_default_uses_constants(self):
+        """Test that calling with no args uses module-level constants."""
+        from runpod_flash.core.resources.constants import FLASH_WORKER_VERSION
+
+        cmd = build_injection_cmd()
+
+        assert f"FW_VER={FLASH_WORKER_VERSION}" in cmd
+        assert f"v{FLASH_WORKER_VERSION}" in cmd
+
+    def test_strip_components_in_remote_extraction(self):
+        """Test tar uses --strip-components=1 for remote downloads."""
+        cmd = build_injection_cmd(worker_version="1.0.0")
+
+        assert "--strip-components=1" in cmd
+
+    def test_strip_components_in_local_extraction(self):
+        """Test tar uses --strip-components=1 for local file extraction."""
+        cmd = build_injection_cmd(
+            worker_version="1.0.0",
+            tarball_url="file:///tmp/fw.tar.gz",
+        )
+
+        assert "--strip-components=1" in cmd

--- a/tests/unit/resources/test_live_load_balancer.py
+++ b/tests/unit/resources/test_live_load_balancer.py
@@ -1,11 +1,13 @@
-"""
-Unit tests for LiveLoadBalancer class and template serialization.
-"""
+"""Unit tests for LiveLoadBalancer class and template serialization."""
 
+import importlib
 import os
 
 import pytest
-
+from runpod_flash.core.resources.constants import (
+    GPU_BASE_IMAGE_PYTHON_VERSION,
+    local_python_version,
+)
 from runpod_flash.core.resources.cpu import CpuInstanceType
 from runpod_flash.core.resources.live_serverless import (
     CpuLiveLoadBalancer,
@@ -23,7 +25,6 @@ class TestLiveLoadBalancer:
         """Test LiveLoadBalancer creates with local image tag."""
         monkeypatch.setenv("FLASH_IMAGE_TAG", "local")
         # Need to reload modules to pick up new env var
-        import importlib
         import runpod_flash.core.resources.constants as const_module
         import runpod_flash.core.resources.live_serverless as ls_module
 
@@ -42,21 +43,30 @@ class TestLiveLoadBalancer:
         os.environ.pop("FLASH_IMAGE_TAG", None)
 
         lb = LiveLoadBalancer(name="test-lb")
-
-        assert "runpod/flash-lb:" in lb.imageName
+        assert f"py{GPU_BASE_IMAGE_PYTHON_VERSION}" in lb.imageName
         assert lb.template is not None
         assert lb.template.imageName == lb.imageName
+
+    def test_live_load_balancer_user_can_override_image(self):
+        """Test user can set custom imageName (BYOI)."""
+        lb = LiveLoadBalancer(name="test-lb", imageName="custom/image:v1")
+        # imageName property returns _live_image, setter is no-op
+        assert lb.imageName is not None
 
     def test_live_load_balancer_template_creation(self):
         """Test LiveLoadBalancer creates proper template from imageName."""
         lb = LiveLoadBalancer(name="cpu_processor")
 
-        # Should have a template created from imageName
         assert lb.template is not None
         assert lb.template.imageName == lb.imageName
-        # Template name uses resource IDs, not the original name
         assert "LiveLoadBalancer" in lb.template.name
         assert "PodTemplate" in lb.template.name
+
+    def test_live_load_balancer_template_has_docker_args(self):
+        """Test LiveLoadBalancer template has process injection dockerArgs."""
+        lb = LiveLoadBalancer(name="test-lb")
+        assert lb.template.dockerArgs
+        assert "bootstrap.sh" in lb.template.dockerArgs
 
     def test_live_load_balancer_template_env_variables(self):
         """Test LiveLoadBalancer template includes environment variables."""
@@ -69,7 +79,6 @@ class TestLiveLoadBalancer:
         assert lb.template.env is not None
         assert len(lb.template.env) > 0
 
-        # Check for custom env var
         custom_vars = [kv for kv in lb.template.env if kv.key == "CUSTOM_VAR"]
         assert len(custom_vars) == 1
         assert custom_vars[0].value == "custom_value"
@@ -78,14 +87,11 @@ class TestLiveLoadBalancer:
         """Test LiveLoadBalancer serializes correctly for GraphQL deployment."""
         lb = LiveLoadBalancer(name="data_processor")
 
-        # Generate payload as would be sent to RunPod
         payload = lb.model_dump(exclude=lb._input_only, exclude_none=True, mode="json")
 
-        # Template must be in payload (not imageName since that's in _input_only)
         assert "template" in payload
         assert "imageName" not in payload
 
-        # Template must have all required fields
         template = payload["template"]
         assert "imageName" in template
         assert "name" in template
@@ -94,14 +100,11 @@ class TestLiveLoadBalancer:
     def test_live_load_balancer_type_is_lb(self):
         """Test LiveLoadBalancer has type=LB."""
         lb = LiveLoadBalancer(name="test-lb")
-
         assert lb.type.value == "LB"
-        assert str(lb.type) == "ServerlessType.LB"
 
     def test_live_load_balancer_scaler_is_request_count(self):
         """Test LiveLoadBalancer uses REQUEST_COUNT scaler."""
         lb = LiveLoadBalancer(name="test-lb")
-
         assert lb.scalerType.value == "REQUEST_COUNT"
 
 
@@ -147,21 +150,15 @@ class TestTemplateSerializationRoundtrip:
             env={"API_KEY": "secret123"},
         )
 
-        # Simulate what gets sent to RunPod
         payload = lb.model_dump(exclude=lb._input_only, exclude_none=True, mode="json")
 
-        # Verify GraphQL payload has template
         assert "template" in payload, "Template must be in GraphQL payload"
         assert payload["template"]["imageName"] is not None
         assert payload["template"]["name"] is not None
-
-        # Verify imageName is NOT in payload (it's in _input_only)
         assert "imageName" not in payload
 
-        # Verify the template has the correct image
-        assert "flash-lb:" in payload["template"]["imageName"], (
-            "Must have load-balancer image"
-        )
+        # dockerArgs must contain injection command
+        assert "bootstrap.sh" in payload["template"]["dockerArgs"]
 
     def test_template_env_serialization(self):
         """Test template environment variables serialize correctly."""
@@ -176,7 +173,6 @@ class TestTemplateSerializationRoundtrip:
         assert isinstance(template_env, list)
         assert len(template_env) >= 2
 
-        # Check env vars are serialized as {key, value} objects
         var_keys = {kv["key"] for kv in template_env}
         assert "VAR1" in var_keys
         assert "VAR2" in var_keys
@@ -189,7 +185,6 @@ class TestCpuLiveLoadBalancer:
         """Test CpuLiveLoadBalancer creates with local image tag."""
         monkeypatch.setenv("FLASH_IMAGE_TAG", "local")
         # Need to reload modules to pick up new env var
-        import importlib
         import runpod_flash.core.resources.constants as const_module
         import runpod_flash.core.resources.live_serverless as ls_module
 
@@ -208,16 +203,19 @@ class TestCpuLiveLoadBalancer:
         os.environ.pop("FLASH_IMAGE_TAG", None)
 
         lb = CpuLiveLoadBalancer(name="test-lb")
-
-        assert "runpod/flash-lb-cpu:" in lb.imageName
+        assert f"py{local_python_version()}" in lb.imageName
         assert lb.template is not None
         assert lb.template.imageName == lb.imageName
+
+    def test_cpu_live_load_balancer_user_can_override_image(self):
+        """Test CpuLiveLoadBalancer allows user image override."""
+        lb = CpuLiveLoadBalancer(name="test-lb", imageName="python:3.11-slim")
+        # imageName property returns _live_image, setter is no-op
+        assert lb.imageName is not None
 
     def test_cpu_live_load_balancer_defaults(self):
         """Test CpuLiveLoadBalancer defaults to CPU3G_2_8."""
         lb = CpuLiveLoadBalancer(name="test-lb")
-
-        # Should default to CPU3G_2_8
         assert lb.instanceIds == [CpuInstanceType.CPU3G_2_8]
 
     def test_cpu_live_load_balancer_with_specific_cpu_instances(self):
@@ -226,34 +224,27 @@ class TestCpuLiveLoadBalancer:
             name="test-lb",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
-
         assert lb.instanceIds == [CpuInstanceType.CPU3G_1_4]
 
     def test_cpu_live_load_balancer_type_is_lb(self):
         """Test CpuLiveLoadBalancer has type=LB."""
         lb = CpuLiveLoadBalancer(name="test-lb")
-
         assert lb.type.value == "LB"
-        assert str(lb.type) == "ServerlessType.LB"
 
     def test_cpu_live_load_balancer_scaler_is_request_count(self):
         """Test CpuLiveLoadBalancer uses REQUEST_COUNT scaler."""
         lb = CpuLiveLoadBalancer(name="test-lb")
-
         assert lb.scalerType.value == "REQUEST_COUNT"
 
     def test_cpu_live_load_balancer_payload_serialization(self):
         """Test CpuLiveLoadBalancer serializes correctly for GraphQL deployment."""
         lb = CpuLiveLoadBalancer(name="data_processor")
 
-        # Generate payload as would be sent to RunPod
         payload = lb.model_dump(exclude=lb._input_only, exclude_none=True, mode="json")
 
-        # Template must be in payload (not imageName since that's in _input_only)
         assert "template" in payload
         assert "imageName" not in payload
 
-        # Template must have all required fields
         template = payload["template"]
         assert "imageName" in template
         assert "name" in template
@@ -265,7 +256,12 @@ class TestCpuLiveLoadBalancer:
 
         payload = lb.model_dump(exclude=lb._input_only, exclude_none=True, mode="json")
 
-        # GPU-specific fields should not be in payload
         assert "gpus" not in payload
         assert "gpuIds" not in payload
         assert "cudaVersions" not in payload
+
+    def test_cpu_live_load_balancer_template_has_docker_args(self):
+        """Test CpuLiveLoadBalancer template has process injection dockerArgs."""
+        lb = CpuLiveLoadBalancer(name="test-lb")
+        assert lb.template.dockerArgs
+        assert "bootstrap.sh" in lb.template.dockerArgs

--- a/tests/unit/resources/test_live_load_balancer.py
+++ b/tests/unit/resources/test_live_load_balancer.py
@@ -50,8 +50,7 @@ class TestLiveLoadBalancer:
     def test_live_load_balancer_user_can_override_image(self):
         """Test user can set custom imageName (BYOI)."""
         lb = LiveLoadBalancer(name="test-lb", imageName="custom/image:v1")
-        # imageName property returns _live_image, setter is no-op
-        assert lb.imageName is not None
+        assert lb.imageName == "custom/image:v1"
 
     def test_live_load_balancer_template_creation(self):
         """Test LiveLoadBalancer creates proper template from imageName."""
@@ -210,8 +209,7 @@ class TestCpuLiveLoadBalancer:
     def test_cpu_live_load_balancer_user_can_override_image(self):
         """Test CpuLiveLoadBalancer allows user image override."""
         lb = CpuLiveLoadBalancer(name="test-lb", imageName="python:3.11-slim")
-        # imageName property returns _live_image, setter is no-op
-        assert lb.imageName is not None
+        assert lb.imageName == "python:3.11-slim"
 
     def test_cpu_live_load_balancer_defaults(self):
         """Test CpuLiveLoadBalancer defaults to CPU3G_2_8."""

--- a/tests/unit/resources/test_live_load_balancer.py
+++ b/tests/unit/resources/test_live_load_balancer.py
@@ -5,8 +5,8 @@ import os
 
 import pytest
 from runpod_flash.core.resources.constants import (
+    DEFAULT_PYTHON_VERSION,
     GPU_BASE_IMAGE_PYTHON_VERSION,
-    local_python_version,
 )
 from runpod_flash.core.resources.cpu import CpuInstanceType
 from runpod_flash.core.resources.live_serverless import (
@@ -202,7 +202,7 @@ class TestCpuLiveLoadBalancer:
         os.environ.pop("FLASH_IMAGE_TAG", None)
 
         lb = CpuLiveLoadBalancer(name="test-lb")
-        assert f"py{local_python_version()}" in lb.imageName
+        assert f"py{DEFAULT_PYTHON_VERSION}" in lb.imageName
         assert lb.template is not None
         assert lb.template.imageName == lb.imageName
 

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -44,9 +44,7 @@ class TestLiveServerless:
         live_serverless = LiveServerless(
             name="test", imageName="nvidia/cuda:12.8.0-runtime-ubuntu22.04"
         )
-        # imageName setter is a no-op, so value is always the computed _live_image
-        # The model_validator sets data["imageName"] but the property overrides reads
-        assert live_serverless.imageName is not None
+        assert live_serverless.imageName == "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
 
     def test_live_serverless_with_custom_template(self):
         """Test LiveServerless with custom template."""
@@ -102,8 +100,7 @@ class TestCpuLiveServerless:
     def test_cpu_live_serverless_user_can_override_image(self):
         """Test CpuLiveServerless allows user to set custom image."""
         live_serverless = CpuLiveServerless(name="test", imageName="python:3.11-slim")
-        # imageName property returns _live_image, setter is no-op
-        assert live_serverless.imageName is not None
+        assert live_serverless.imageName == "python:3.11-slim"
 
     def test_cpu_live_serverless_validation_failure(self):
         """Test CpuLiveServerless validation fails with excessive disk size."""
@@ -200,23 +197,15 @@ class TestLiveServerlessMixin:
         assert lb.template is not None
         assert lb.template.dockerArgs
 
-    def test_image_name_setter_ignored_gpu(self):
-        """Test LiveServerless imageName setter is ignored."""
-        live_serverless = LiveServerless(name="test")
-        original_image = live_serverless.imageName
+    def test_live_serverless_byoi_gpu(self):
+        """Test LiveServerless respects user-provided imageName."""
+        live_serverless = LiveServerless(name="test", imageName="custom/gpu:v1")
+        assert live_serverless.imageName == "custom/gpu:v1"
 
-        live_serverless.imageName = "should-be-ignored"
-
-        assert live_serverless.imageName == original_image
-
-    def test_image_name_setter_ignored_cpu(self):
-        """Test CpuLiveServerless imageName setter is ignored."""
-        live_serverless = CpuLiveServerless(name="test")
-        original_image = live_serverless.imageName
-
-        live_serverless.imageName = "should-be-ignored"
-
-        assert live_serverless.imageName == original_image
+    def test_live_serverless_byoi_cpu(self):
+        """Test CpuLiveServerless respects user-provided imageName."""
+        live_serverless = CpuLiveServerless(name="test", imageName="custom/cpu:v1")
+        assert live_serverless.imageName == "custom/cpu:v1"
 
 
 class TestLiveServerlessPythonVersion:

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for LiveServerless and CpuLiveServerless classes.
-"""
+"""Unit tests for LiveServerless, CpuLiveServerless, and LiveServerlessMixin."""
 
 import pytest
 from runpod_flash.core.resources.constants import (
@@ -8,10 +6,10 @@ from runpod_flash.core.resources.constants import (
 )
 from runpod_flash.core.resources.cpu import CpuInstanceType
 from runpod_flash.core.resources.live_serverless import (
-    LiveServerless,
+    CpuLiveLoadBalancer,
     CpuLiveServerless,
     LiveLoadBalancer,
-    CpuLiveLoadBalancer,
+    LiveServerless,
 )
 from runpod_flash.core.resources.template import PodTemplate
 
@@ -34,30 +32,21 @@ class TestLiveServerless:
             LiveServerless(name="broken", idleTimeout=0)
 
     def test_live_serverless_gpu_defaults(self):
-        """Test LiveServerless uses GPU image and defaults."""
-        live_serverless = LiveServerless(
-            name="example_gpu_live_serverless",
-        )
+        """Test LiveServerless uses GPU base image and defaults."""
+        live_serverless = LiveServerless(name="example_gpu_live_serverless")
 
-        # Should not have CPU instances, uses default 64GB
         assert live_serverless.instanceIds is None
         assert live_serverless.template is not None
         assert live_serverless.template.containerDiskInGb == 64
-        assert "flash:" in live_serverless.imageName  # GPU image
 
-    def test_live_serverless_image_locked(self):
-        """Test LiveServerless imageName is locked to GPU image."""
+    def test_live_serverless_user_can_override_image(self):
+        """Test user can set custom imageName (BYOI)."""
         live_serverless = LiveServerless(
-            name="example_gpu_live_serverless",
+            name="test", imageName="nvidia/cuda:12.8.0-runtime-ubuntu22.04"
         )
-
-        original_image = live_serverless.imageName
-
-        # Attempt to change imageName - should be ignored
-        live_serverless.imageName = "custom/image:latest"
-
-        assert live_serverless.imageName == original_image
-        assert "flash:" in live_serverless.imageName  # Still GPU image
+        # imageName setter is a no-op, so value is always the computed _live_image
+        # The model_validator sets data["imageName"] but the property overrides reads
+        assert live_serverless.imageName is not None
 
     def test_live_serverless_with_custom_template(self):
         """Test LiveServerless with custom template."""
@@ -66,14 +55,18 @@ class TestLiveServerless:
             imageName="test/image:v1",
             containerDiskInGb=100,
         )
-
         live_serverless = LiveServerless(
             name="example_gpu_live_serverless",
             template=template,
         )
-
-        # Should preserve custom template settings
         assert live_serverless.template.containerDiskInGb == 100
+
+    def test_live_serverless_template_has_docker_args(self):
+        """Test that the template includes dockerArgs for process injection."""
+        live_serverless = LiveServerless(name="test")
+        assert live_serverless.template is not None
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
 
 class TestCpuLiveServerless:
@@ -81,16 +74,11 @@ class TestCpuLiveServerless:
 
     def test_cpu_live_serverless_defaults(self):
         """Test CpuLiveServerless uses CPU image and auto-sizing."""
-        live_serverless = CpuLiveServerless(
-            name="example_cpu_live_serverless",
-        )
+        live_serverless = CpuLiveServerless(name="example_cpu_live_serverless")
 
-        # Should default to CPU3G_2_8
         assert live_serverless.instanceIds == [CpuInstanceType.CPU3G_2_8]
         assert live_serverless.template is not None
-        # Default disk size should be 20GB for CPU3G_2_8
         assert live_serverless.template.containerDiskInGb == 20
-        assert "flash-cpu:" in live_serverless.imageName  # CPU image
 
     def test_cpu_live_serverless_custom_instances(self):
         """Test CpuLiveServerless with custom CPU instances."""
@@ -98,7 +86,6 @@ class TestCpuLiveServerless:
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
-
         assert live_serverless.instanceIds == [CpuInstanceType.CPU3G_1_4]
         assert live_serverless.template is not None
         assert live_serverless.template.containerDiskInGb == 10
@@ -109,33 +96,22 @@ class TestCpuLiveServerless:
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4, CpuInstanceType.CPU5C_2_4],
         )
-
         assert live_serverless.template is not None
-        assert live_serverless.template.containerDiskInGb == 10  # Min of 10 and 30
+        assert live_serverless.template.containerDiskInGb == 10
 
-    def test_cpu_live_serverless_image_locked(self):
-        """Test CpuLiveServerless imageName is locked to CPU image."""
-        live_serverless = CpuLiveServerless(
-            name="example_cpu_live_serverless",
-            instanceIds=[CpuInstanceType.CPU3G_1_4],
-        )
-
-        original_image = live_serverless.imageName
-
-        # Attempt to change imageName - should be ignored
-        live_serverless.imageName = "custom/image:latest"
-
-        assert live_serverless.imageName == original_image
-        assert "flash-cpu:" in live_serverless.imageName  # Still CPU image
+    def test_cpu_live_serverless_user_can_override_image(self):
+        """Test CpuLiveServerless allows user to set custom image."""
+        live_serverless = CpuLiveServerless(name="test", imageName="python:3.11-slim")
+        # imageName property returns _live_image, setter is no-op
+        assert live_serverless.imageName is not None
 
     def test_cpu_live_serverless_validation_failure(self):
         """Test CpuLiveServerless validation fails with excessive disk size."""
         template = PodTemplate(
             name="custom",
             imageName="test/image:v1",
-            containerDiskInGb=50,  # Exceeds 10GB limit
+            containerDiskInGb=50,
         )
-
         with pytest.raises(ValueError, match="Container disk size 50GB exceeds"):
             CpuLiveServerless(
                 name="example_cpu_live_serverless",
@@ -146,58 +122,83 @@ class TestCpuLiveServerless:
     def test_cpu_live_serverless_with_existing_template_default_size(self):
         """Test CpuLiveServerless auto-sizes existing template with default disk size."""
         template = PodTemplate(name="existing", imageName="test/image:v1")
-        # Template uses default size
-
         live_serverless = CpuLiveServerless(
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
             template=template,
         )
-
-        assert live_serverless.template.containerDiskInGb == 10  # Should be auto-sized
+        assert live_serverless.template.containerDiskInGb == 10
 
     def test_cpu_live_serverless_preserves_custom_disk_size(self):
         """Test CpuLiveServerless preserves custom disk size in template."""
         template = PodTemplate(
             name="existing",
             imageName="test/image:v1",
-            containerDiskInGb=5,  # Custom size within limits
+            containerDiskInGb=5,
         )
-
         live_serverless = CpuLiveServerless(
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
             template=template,
         )
+        assert live_serverless.template.containerDiskInGb == 5
 
-        assert (
-            live_serverless.template.containerDiskInGb == 5
-        )  # Should preserve custom size
+    def test_cpu_live_serverless_template_has_docker_args(self):
+        """Test CpuLiveServerless template includes dockerArgs."""
+        live_serverless = CpuLiveServerless(name="test")
+        assert live_serverless.template is not None
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
 
 class TestLiveServerlessMixin:
     """Test LiveServerlessMixin functionality."""
 
-    def test_live_image_property_gpu(self):
-        """Test LiveServerless _live_image property."""
+    def test_docker_args_set_on_new_template(self):
+        """Test dockerArgs is set when creating a new template."""
         live_serverless = LiveServerless(name="test")
-        assert "flash:" in live_serverless._live_image
-        assert "cpu" not in live_serverless._live_image
+        assert live_serverless.template.dockerArgs
+        assert "bash -c" in live_serverless.template.dockerArgs
 
-    def test_live_image_property_cpu(self):
-        """Test CpuLiveServerless _live_image property."""
-        live_serverless = CpuLiveServerless(name="test")
-        assert "flash-cpu:" in live_serverless._live_image
+    def test_docker_args_set_on_existing_template(self):
+        """Test dockerArgs is set when configuring an existing template."""
+        template = PodTemplate(
+            name="existing",
+            imageName="test/image:v1",
+        )
+        live_serverless = LiveServerless(name="test", template=template)
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
-    def test_image_name_property_gpu(self):
-        """Test LiveServerless imageName property returns locked image."""
-        live_serverless = LiveServerless(name="test")
-        assert live_serverless.imageName == live_serverless._live_image
+    def test_all_live_classes_have_docker_args(self):
+        """Test all Live* classes set dockerArgs on their templates."""
+        classes_and_kwargs = [
+            (LiveServerless, {}),
+            (CpuLiveServerless, {}),
+            (LiveLoadBalancer, {}),
+            (CpuLiveLoadBalancer, {}),
+        ]
+        for cls, extra_kwargs in classes_and_kwargs:
+            resource = cls(name=f"test-{cls.__name__}", **extra_kwargs)
+            assert resource.template is not None, f"{cls.__name__} has no template"
+            assert resource.template.dockerArgs, f"{cls.__name__} has no dockerArgs"
+            assert "bootstrap.sh" in resource.template.dockerArgs, (
+                f"{cls.__name__} missing bootstrap.sh in dockerArgs"
+            )
 
-    def test_image_name_property_cpu(self):
-        """Test CpuLiveServerless imageName property returns locked image."""
-        live_serverless = CpuLiveServerless(name="test")
-        assert live_serverless.imageName == live_serverless._live_image
+    def test_live_load_balancer_defaults(self):
+        """Test LiveLoadBalancer uses GPU image."""
+        lb = LiveLoadBalancer(name="test-lb")
+        assert lb.imageName is not None
+        assert lb.template is not None
+        assert lb.template.dockerArgs
+
+    def test_cpu_live_load_balancer_defaults(self):
+        """Test CpuLiveLoadBalancer uses CPU image."""
+        lb = CpuLiveLoadBalancer(name="test-lb-cpu")
+        assert lb.imageName is not None
+        assert lb.template is not None
+        assert lb.template.dockerArgs
 
     def test_image_name_setter_ignored_gpu(self):
         """Test LiveServerless imageName setter is ignored."""

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for LiveServerless and CpuLiveServerless classes.
-"""
+"""Unit tests for LiveServerless, CpuLiveServerless, and LiveServerlessMixin."""
 
 import pytest
 from runpod_flash.core.resources.constants import (
@@ -8,10 +6,10 @@ from runpod_flash.core.resources.constants import (
 )
 from runpod_flash.core.resources.cpu import CpuInstanceType
 from runpod_flash.core.resources.live_serverless import (
-    LiveServerless,
+    CpuLiveLoadBalancer,
     CpuLiveServerless,
     LiveLoadBalancer,
-    CpuLiveLoadBalancer,
+    LiveServerless,
 )
 from runpod_flash.core.resources.template import PodTemplate
 
@@ -34,16 +32,12 @@ class TestLiveServerless:
             LiveServerless(name="broken", idleTimeout=0)
 
     def test_live_serverless_gpu_defaults(self):
-        """Test LiveServerless uses GPU image and defaults."""
-        live_serverless = LiveServerless(
-            name="example_gpu_live_serverless",
-        )
+        """Test LiveServerless uses GPU base image and defaults."""
+        live_serverless = LiveServerless(name="example_gpu_live_serverless")
 
-        # Should not have CPU instances, uses default 64GB
         assert live_serverless.instanceIds is None
         assert live_serverless.template is not None
         assert live_serverless.template.containerDiskInGb == 64
-        assert "flash:" in live_serverless.imageName  # GPU image
 
     def test_live_serverless_image_override_via_constructor(self):
         """LiveServerless accepts a caller-supplied imageName (AE-3153)."""
@@ -59,6 +53,14 @@ class TestLiveServerless:
         """LiveServerless still defaults to the Flash GPU runtime image."""
         live_serverless = LiveServerless(name="example_gpu_live_serverless")
         assert "flash:" in live_serverless.imageName
+    def test_live_serverless_user_can_override_image(self):
+        """Test user can set custom imageName (BYOI)."""
+        live_serverless = LiveServerless(
+            name="test", imageName="nvidia/cuda:12.8.0-runtime-ubuntu22.04"
+        )
+        # imageName setter is a no-op, so value is always the computed _live_image
+        # The model_validator sets data["imageName"] but the property overrides reads
+        assert live_serverless.imageName is not None
 
     def test_live_serverless_with_custom_template(self):
         """Test LiveServerless with custom template."""
@@ -67,14 +69,18 @@ class TestLiveServerless:
             imageName="test/image:v1",
             containerDiskInGb=100,
         )
-
         live_serverless = LiveServerless(
             name="example_gpu_live_serverless",
             template=template,
         )
-
-        # Should preserve custom template settings
         assert live_serverless.template.containerDiskInGb == 100
+
+    def test_live_serverless_template_has_docker_args(self):
+        """Test that the template includes dockerArgs for process injection."""
+        live_serverless = LiveServerless(name="test")
+        assert live_serverless.template is not None
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
 
 class TestCpuLiveServerless:
@@ -82,16 +88,11 @@ class TestCpuLiveServerless:
 
     def test_cpu_live_serverless_defaults(self):
         """Test CpuLiveServerless uses CPU image and auto-sizing."""
-        live_serverless = CpuLiveServerless(
-            name="example_cpu_live_serverless",
-        )
+        live_serverless = CpuLiveServerless(name="example_cpu_live_serverless")
 
-        # Should default to CPU3G_2_8
         assert live_serverless.instanceIds == [CpuInstanceType.CPU3G_2_8]
         assert live_serverless.template is not None
-        # Default disk size should be 20GB for CPU3G_2_8
         assert live_serverless.template.containerDiskInGb == 20
-        assert "flash-cpu:" in live_serverless.imageName  # CPU image
 
     def test_cpu_live_serverless_custom_instances(self):
         """Test CpuLiveServerless with custom CPU instances."""
@@ -99,7 +100,6 @@ class TestCpuLiveServerless:
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
-
         assert live_serverless.instanceIds == [CpuInstanceType.CPU3G_1_4]
         assert live_serverless.template is not None
         assert live_serverless.template.containerDiskInGb == 10
@@ -110,9 +110,8 @@ class TestCpuLiveServerless:
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4, CpuInstanceType.CPU5C_2_4],
         )
-
         assert live_serverless.template is not None
-        assert live_serverless.template.containerDiskInGb == 10  # Min of 10 and 30
+        assert live_serverless.template.containerDiskInGb == 10
 
     def test_cpu_live_serverless_image_override_via_constructor(self):
         """CpuLiveServerless accepts a caller-supplied imageName (AE-3153)."""
@@ -131,15 +130,19 @@ class TestCpuLiveServerless:
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
         assert "flash-cpu:" in live_serverless.imageName
+    def test_cpu_live_serverless_user_can_override_image(self):
+        """Test CpuLiveServerless allows user to set custom image."""
+        live_serverless = CpuLiveServerless(name="test", imageName="python:3.11-slim")
+        # imageName property returns _live_image, setter is no-op
+        assert live_serverless.imageName is not None
 
     def test_cpu_live_serverless_validation_failure(self):
         """Test CpuLiveServerless validation fails with excessive disk size."""
         template = PodTemplate(
             name="custom",
             imageName="test/image:v1",
-            containerDiskInGb=50,  # Exceeds 10GB limit
+            containerDiskInGb=50,
         )
-
         with pytest.raises(ValueError, match="Container disk size 50GB exceeds"):
             CpuLiveServerless(
                 name="example_cpu_live_serverless",
@@ -150,48 +153,53 @@ class TestCpuLiveServerless:
     def test_cpu_live_serverless_with_existing_template_default_size(self):
         """Test CpuLiveServerless auto-sizes existing template with default disk size."""
         template = PodTemplate(name="existing", imageName="test/image:v1")
-        # Template uses default size
-
         live_serverless = CpuLiveServerless(
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
             template=template,
         )
-
-        assert live_serverless.template.containerDiskInGb == 10  # Should be auto-sized
+        assert live_serverless.template.containerDiskInGb == 10
 
     def test_cpu_live_serverless_preserves_custom_disk_size(self):
         """Test CpuLiveServerless preserves custom disk size in template."""
         template = PodTemplate(
             name="existing",
             imageName="test/image:v1",
-            containerDiskInGb=5,  # Custom size within limits
+            containerDiskInGb=5,
         )
-
         live_serverless = CpuLiveServerless(
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
             template=template,
         )
+        assert live_serverless.template.containerDiskInGb == 5
 
-        assert (
-            live_serverless.template.containerDiskInGb == 5
-        )  # Should preserve custom size
+    def test_cpu_live_serverless_template_has_docker_args(self):
+        """Test CpuLiveServerless template includes dockerArgs."""
+        live_serverless = CpuLiveServerless(name="test")
+        assert live_serverless.template is not None
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
 
 class TestLiveServerlessMixin:
     """Test LiveServerlessMixin functionality."""
 
-    def test_live_image_property_gpu(self):
-        """Test LiveServerless _live_image property."""
+    def test_docker_args_set_on_new_template(self):
+        """Test dockerArgs is set when creating a new template."""
         live_serverless = LiveServerless(name="test")
-        assert "flash:" in live_serverless._live_image
-        assert "cpu" not in live_serverless._live_image
+        assert live_serverless.template.dockerArgs
+        assert "bash -c" in live_serverless.template.dockerArgs
 
-    def test_live_image_property_cpu(self):
-        """Test CpuLiveServerless _live_image property."""
-        live_serverless = CpuLiveServerless(name="test")
-        assert "flash-cpu:" in live_serverless._live_image
+    def test_docker_args_set_on_existing_template(self):
+        """Test dockerArgs is set when configuring an existing template."""
+        template = PodTemplate(
+            name="existing",
+            imageName="test/image:v1",
+        )
+        live_serverless = LiveServerless(name="test", template=template)
+        assert live_serverless.template.dockerArgs
+        assert "bootstrap.sh" in live_serverless.template.dockerArgs
 
     def test_image_name_property_gpu(self):
         """LiveServerless defaults imageName to the Flash runtime image when none supplied."""
@@ -202,6 +210,35 @@ class TestLiveServerlessMixin:
         """CpuLiveServerless defaults imageName to the Flash runtime image when none supplied."""
         live_serverless = CpuLiveServerless(name="test")
         assert live_serverless.imageName == live_serverless._live_image
+    def test_all_live_classes_have_docker_args(self):
+        """Test all Live* classes set dockerArgs on their templates."""
+        classes_and_kwargs = [
+            (LiveServerless, {}),
+            (CpuLiveServerless, {}),
+            (LiveLoadBalancer, {}),
+            (CpuLiveLoadBalancer, {}),
+        ]
+        for cls, extra_kwargs in classes_and_kwargs:
+            resource = cls(name=f"test-{cls.__name__}", **extra_kwargs)
+            assert resource.template is not None, f"{cls.__name__} has no template"
+            assert resource.template.dockerArgs, f"{cls.__name__} has no dockerArgs"
+            assert "bootstrap.sh" in resource.template.dockerArgs, (
+                f"{cls.__name__} missing bootstrap.sh in dockerArgs"
+            )
+
+    def test_live_load_balancer_defaults(self):
+        """Test LiveLoadBalancer uses GPU image."""
+        lb = LiveLoadBalancer(name="test-lb")
+        assert lb.imageName is not None
+        assert lb.template is not None
+        assert lb.template.dockerArgs
+
+    def test_cpu_live_load_balancer_defaults(self):
+        """Test CpuLiveLoadBalancer uses CPU image."""
+        lb = CpuLiveLoadBalancer(name="test-lb-cpu")
+        assert lb.imageName is not None
+        assert lb.template is not None
+        assert lb.template.dockerArgs
 
     def test_image_name_override_gpu(self):
         """LiveServerless honors caller-supplied imageName (AE-3153)."""

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -58,9 +58,7 @@ class TestLiveServerless:
         live_serverless = LiveServerless(
             name="test", imageName="nvidia/cuda:12.8.0-runtime-ubuntu22.04"
         )
-        # imageName setter is a no-op, so value is always the computed _live_image
-        # The model_validator sets data["imageName"] but the property overrides reads
-        assert live_serverless.imageName is not None
+        assert live_serverless.imageName == "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
 
     def test_live_serverless_with_custom_template(self):
         """Test LiveServerless with custom template."""
@@ -133,8 +131,7 @@ class TestCpuLiveServerless:
     def test_cpu_live_serverless_user_can_override_image(self):
         """Test CpuLiveServerless allows user to set custom image."""
         live_serverless = CpuLiveServerless(name="test", imageName="python:3.11-slim")
-        # imageName property returns _live_image, setter is no-op
-        assert live_serverless.imageName is not None
+        assert live_serverless.imageName == "python:3.11-slim"
 
     def test_cpu_live_serverless_validation_failure(self):
         """Test CpuLiveServerless validation fails with excessive disk size."""
@@ -265,6 +262,15 @@ class TestLiveServerlessMixin:
         original = LiveServerless(name="test", imageName="byo/image:v1")
         revalidated = LiveServerless.model_validate(original)
         assert revalidated.imageName == "byo/image:v1"
+    def test_live_serverless_byoi_gpu(self):
+        """Test LiveServerless respects user-provided imageName."""
+        live_serverless = LiveServerless(name="test", imageName="custom/gpu:v1")
+        assert live_serverless.imageName == "custom/gpu:v1"
+
+    def test_live_serverless_byoi_cpu(self):
+        """Test CpuLiveServerless respects user-provided imageName."""
+        live_serverless = CpuLiveServerless(name="test", imageName="custom/cpu:v1")
+        assert live_serverless.imageName == "custom/cpu:v1"
 
 
 class TestLiveServerlessPythonVersion:

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -53,6 +53,7 @@ class TestLiveServerless:
         """LiveServerless still defaults to the Flash GPU runtime image."""
         live_serverless = LiveServerless(name="example_gpu_live_serverless")
         assert "flash:" in live_serverless.imageName
+
     def test_live_serverless_user_can_override_image(self):
         """Test user can set custom imageName (BYOI)."""
         live_serverless = LiveServerless(
@@ -128,6 +129,7 @@ class TestCpuLiveServerless:
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
         assert "flash-cpu:" in live_serverless.imageName
+
     def test_cpu_live_serverless_user_can_override_image(self):
         """Test CpuLiveServerless allows user to set custom image."""
         live_serverless = CpuLiveServerless(name="test", imageName="python:3.11-slim")
@@ -200,13 +202,28 @@ class TestLiveServerlessMixin:
 
     def test_image_name_property_gpu(self):
         """LiveServerless defaults imageName to the Flash runtime image when none supplied."""
+        from runpod_flash.core.resources.constants import (
+            DEFAULT_PYTHON_VERSION,
+            get_image_name,
+        )
+
         live_serverless = LiveServerless(name="test")
-        assert live_serverless.imageName == live_serverless._live_image
+        assert live_serverless.imageName == get_image_name(
+            "gpu", DEFAULT_PYTHON_VERSION
+        )
 
     def test_image_name_property_cpu(self):
         """CpuLiveServerless defaults imageName to the Flash runtime image when none supplied."""
+        from runpod_flash.core.resources.constants import (
+            DEFAULT_PYTHON_VERSION,
+            get_image_name,
+        )
+
         live_serverless = CpuLiveServerless(name="test")
-        assert live_serverless.imageName == live_serverless._live_image
+        assert live_serverless.imageName == get_image_name(
+            "cpu", DEFAULT_PYTHON_VERSION
+        )
+
     def test_all_live_classes_have_docker_args(self):
         """Test all Live* classes set dockerArgs on their templates."""
         classes_and_kwargs = [
@@ -262,6 +279,7 @@ class TestLiveServerlessMixin:
         original = LiveServerless(name="test", imageName="byo/image:v1")
         revalidated = LiveServerless.model_validate(original)
         assert revalidated.imageName == "byo/image:v1"
+
     def test_live_serverless_byoi_gpu(self):
         """Test LiveServerless respects user-provided imageName."""
         live_serverless = LiveServerless(name="test", imageName="custom/gpu:v1")


### PR DESCRIPTION
## Summary
- Add `injection.py` with `build_injection_cmd()` for dockerArgs generation
- Add base image constants (`FLASH_GPU_BASE_IMAGE`, `FLASH_CPU_BASE_IMAGE`)
- Update `LiveServerlessMixin` to configure dockerArgs on templates for tarball injection
- Add `_default_base_image` and `_legacy_image` properties to all Live* resource classes
- Unify CPU base image to `python:3.11-slim` (matching GPU PyTorch runtime)
- Worker tarball URL configurable via `FLASH_WORKER_TARBALL_URL` env var

## Test plan
- [ ] `make quality-check` passes
- [ ] `LiveServerless` template includes dockerArgs with bootstrap command
- [ ] `FLASH_WORKER_TARBALL_URL=<url> flash deploy` provisions endpoint with injection
- [ ] Preview mode still works via legacy Docker images

Depends on: runpod-workers/flash#75 (tarball build pipeline)