### PR TITLE
fix(deployment): join background deploy thread to stop cross-test state leak

### DIFF
--- a/src/runpod_flash/core/deployment.py
+++ b/src/runpod_flash/core/deployment.py
@@ -6,7 +6,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -55,7 +55,9 @@ class DeploymentOrchestrator:
         self.manager = ResourceManager()
         self.results: List[DeploymentResult] = []
 
-    def deploy_all_background(self, resources: List[DeployableResource]) -> None:
+    def deploy_all_background(
+        self, resources: List[DeployableResource]
+    ) -> Optional[threading.Thread]:
         """Deploy all resources in background thread.
 
         This method spawns a background thread to deploy resources without
@@ -63,10 +65,17 @@ class DeploymentOrchestrator:
 
         Args:
             resources: List of resources to deploy
+
+        Returns:
+            The worker thread, or None when there was nothing to deploy.
+            Callers that need the deployment to finish within a bounded scope
+            (notably tests, which patch the deploy path) must join it —
+            otherwise the daemon thread outlives that scope and mutates
+            ResourceManager's class-level state afterwards.
         """
         if not resources:
             console.print("[dim]No resources to deploy[/dim]")
-            return
+            return None
 
         def run_async_deployment():
             """Run async deployment in background thread."""
@@ -90,6 +99,7 @@ class DeploymentOrchestrator:
         console.print(
             f"[dim]Auto-provisioning {len(resources)} resource(s) in background...[/dim]"
         )
+        return thread
 
     async def deploy_all(
         self, resources: List[DeployableResource], show_progress: bool = True

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -2,6 +2,7 @@
 
 import pytest
 import asyncio
+import threading
 from unittest.mock import MagicMock, AsyncMock, patch
 
 from runpod_flash.core.deployment import (
@@ -204,17 +205,43 @@ class TestDeploymentOrchestrator:
             mock_deploy.side_effect = mock_resources
 
             # Should not block
-            orchestrator.deploy_all_background(mock_resources)
+            thread = orchestrator.deploy_all_background(mock_resources)
 
-            # Background thread should be started
-            # (not much we can test here without waiting for thread)
+            # Join inside the patch context so the worker cannot outlive the
+            # mock and reach the real deploy path. See the returns-a-thread
+            # test below for why this matters.
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+
+    def test_deploy_all_background_returns_joinable_thread(self, mock_resources):
+        """Callers must be able to await background deployment.
+
+        Without a handle to join, the daemon thread outlives the caller's
+        patches and runs the real deploy path afterwards, writing mock
+        resources into the ResourceManager class-level state. That state is
+        shared process-wide, so an unrelated test later fails when it tries
+        to cloudpickle the leftover mock.
+        """
+        orchestrator = DeploymentOrchestrator()
+
+        with patch.object(
+            orchestrator.manager, "get_or_deploy_resource", new_callable=AsyncMock
+        ) as mock_deploy:
+            mock_deploy.side_effect = mock_resources
+
+            thread = orchestrator.deploy_all_background(mock_resources)
+
+            assert isinstance(thread, threading.Thread)
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+            assert mock_deploy.await_count == len(mock_resources)
 
     def test_deploy_all_background_empty_list(self):
         """Test background deployment with empty list."""
         orchestrator = DeploymentOrchestrator()
 
-        # Should handle gracefully
-        orchestrator.deploy_all_background([])
+        # Nothing to deploy means no thread to join.
+        assert orchestrator.deploy_all_background([]) is None
 
     @pytest.mark.asyncio
     async def test_deploy_all_raises_api_key_error_before_deploying(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version < '3.13'",


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure

```
FAILED tests/unit/test_regressions.py::TestREG008NonInteractiveEnvDelete::test_undeploy_resource_force_remove_no_tty
  - _pickle.PicklingError: args[0] from __newobj__ args has the wrong class
```

which has been hitting a single Python version at random on unrelated PRs.

`FAILED <nodeid> - <exc>` means the **test itself** raised, not xdist failing to serialize a report — the victim test is innocent.

## Root cause

1. `deploy_all_background()` spawns a **daemon thread and returns nothing**, so callers have no handle to join.
2. `test_deploy_all_background` patched `get_or_deploy_resource`, started the thread, and returned immediately. The patch unwound **while the worker was still running**, so the thread went on to hit the real deploy path with `AsyncMock` resources and cached them via `_add_resource`.
3. `ResourceManager._resources` is a **class variable**. The late write lands in whichever dict is current when it happens — one belonging to a *later* test.
4. The next test to call `_save_resources()` cloudpickles that leftover `AsyncMock` and dies.

The autouse `reset_singletons` fixture is already correct and function-scoped; it cannot help, because the rogue write happens *after* the reset. Which test pays depends on thread scheduling and xdist load distribution — hence the randomness.

Traced rather than inferred, via a plugin recording which test inserted each `_resources` entry:

```
### SAVE FAILED during test: tests/unit/test_regressions.py::TestREG008...
### CULPRIT key=<MagicMock name='mock.get_resource_key()'> type=<class 'unittest.mock.AsyncMock'>
    inserted_by=tests/unit/test_deployment.py::TestDeploymentOrchestrator::test_deploy_all_background
```

## Changes

- `deploy_all_background` returns `Optional[threading.Thread]`. Backwards-compatible — it previously returned `None` implicitly, and no production caller reads the value.
- `test_deploy_all_background` joins inside the patch context, so the worker can no longer outlive the mock.
- New `test_deploy_all_background_returns_joinable_thread` pins the contract and asserts the deploy mock absorbed every resource.
- Empty-list path asserts `None`.
- Separate commit resyncs `uv.lock`'s `requires-python` (`<3.13` → `<3.14`) with `pyproject.toml`; CI already runs a 3.13 job. Resolution unchanged, no package versions move.

## Test plan

Written test-first; the new test failed with `AttributeError: 'NoneType' object has no attribute 'join'` before the fix, and the pre-fix run visibly logged the leak (`caching for cleanup` ×3), now absent.

- [x] The serial run reproduces the failure **deterministically** on main: `1 failed, 2629 passed` → now `2618 passed, 0 failed`
- [x] `make quality-check` green (format, lint, 2618 parallel + 53 serial)
- [x] `mypy src/runpod_flash/core/deployment.py` clean
- [x] 3 consecutive `-n auto` runs, all `2618 passed`