### PR TITLE
feat: add unrestricted serverless placement

### DIFF
--- a/src/runpod_flash/core/resources/load_balancer_sls_resource.py
+++ b/src/runpod_flash/core/resources/load_balancer_sls_resource.py
@@ -135,6 +135,7 @@ class LoadBalancerSlsResource(ServerlessResource):
         """
         # Validate before deploying
         self._validate_lb_configuration()
+        self._validate_unrestricted_placement()
 
         # Check if already deployed
         if await self.is_deployed():
@@ -164,6 +165,7 @@ class LoadBalancerSlsResource(ServerlessResource):
         Returns:
             True if the endpoint exists, False otherwise
         """
+        self._validate_unrestricted_placement()
         if not self.id:
             return False
 
@@ -232,6 +234,7 @@ class CpuLoadBalancerSlsResource(CpuEndpointMixin, LoadBalancerSlsResource):
         "networkVolume",
         "networkVolumes",
         "python_version",
+        "unrestrictedLocations",
     }
 
     def _setup_cpu_template(self) -> None:

--- a/src/runpod_flash/core/resources/resource_manager.py
+++ b/src/runpod_flash/core/resources/resource_manager.py
@@ -235,6 +235,10 @@ class ResourceManager(SingletonMixin):
 
         Thread-safe implementation that prevents concurrent deployments.
         """
+        placement_validator = getattr(config, "_validate_unrestricted_placement", None)
+        if placement_validator is not None:
+            placement_validator()
+
         # Use name-based key instead of hash
         resource_key = config.get_resource_key()
         new_config_hash = config.config_hash
@@ -253,6 +257,12 @@ class ResourceManager(SingletonMixin):
             existing = self._resources.get(resource_key)
 
             if existing:
+                existing_placement_validator = getattr(
+                    existing, "_validate_unrestricted_placement", None
+                )
+                if existing_placement_validator is not None:
+                    existing_placement_validator()
+
                 # Resource exists - check if still valid
                 if not await existing.is_deployed():
                     log.warning(f"{existing} is no longer valid, redeploying.")

--- a/src/runpod_flash/core/resources/serverless.py
+++ b/src/runpod_flash/core/resources/serverless.py
@@ -6,6 +6,7 @@ import re
 from collections import Counter
 from datetime import datetime, timezone
 from enum import Enum
+from functools import partial
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
@@ -200,6 +201,19 @@ class ServerlessResource(DeployableResource):
     Base class for GPU serverless resource
     """
 
+    SUPPORTS_UNRESTRICTED_LOCATIONS: ClassVar[bool] = True
+    _UNRESTRICTED_PROVENANCE_STATE_KEY: ClassVar[str] = (
+        "__runpod_flash_unrestricted_endpoint_id__"
+    )
+    _UNRESTRICTED_MARKER_NAMES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "providerHydratedUnrestricted",
+            "provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted_id",
+        }
+    )
+
     _input_only = {
         "id",
         "cudaVersions",
@@ -212,6 +226,7 @@ class ServerlessResource(DeployableResource):
         "networkVolume",
         "networkVolumes",
         "python_version",
+        "unrestrictedLocations",
     }
 
     _hashed_fields = {
@@ -233,6 +248,7 @@ class ServerlessResource(DeployableResource):
         "workersPFBTarget",
         "allowedCudaVersions",
         "type",
+        "unrestrictedLocations",
     }
 
     # Fields assigned by API that shouldn't affect drift detection
@@ -269,6 +285,7 @@ class ServerlessResource(DeployableResource):
         default=None,
         description="Python version for runtime image selection. Defaults to the local interpreter version at build time.",
     )
+    unrestrictedLocations: Optional[bool] = None
 
     # === Input Fields ===
     executionTimeoutMs: Optional[int] = 0
@@ -290,6 +307,7 @@ class ServerlessResource(DeployableResource):
 
     # === Private Attributes ===
     _deployed_volume_ids: list[str] = PrivateAttr(default_factory=list)
+    _provider_hydrated_unrestricted_id: Optional[str] = PrivateAttr(default=None)
 
     # === Runtime Fields ===
     activeBuildid: Optional[str] = None
@@ -546,6 +564,181 @@ class ServerlessResource(DeployableResource):
 
         return hash_value
 
+    @model_validator(mode="before")
+    @classmethod
+    def discard_public_unrestricted_provenance(cls, data):
+        if isinstance(data, dict):
+            data = dict(data)
+            for marker_name in cls._UNRESTRICTED_MARKER_NAMES:
+                data.pop(marker_name, None)
+            data.pop(cls._UNRESTRICTED_PROVENANCE_STATE_KEY, None)
+        return data
+
+    @classmethod
+    def model_construct(cls, _fields_set=None, **values):
+        for marker_name in cls._UNRESTRICTED_MARKER_NAMES:
+            values.pop(marker_name, None)
+        values.pop(cls._UNRESTRICTED_PROVENANCE_STATE_KEY, None)
+        model = super().model_construct(_fields_set=_fields_set, **values)
+        model._set_provider_hydrated_unrestricted_id(None)
+        return model
+
+    def model_copy(self, *, update=None, deep=False):
+        sanitized_update = dict(update or {})
+        for marker_name in self._UNRESTRICTED_MARKER_NAMES:
+            sanitized_update.pop(marker_name, None)
+        sanitized_update.pop(self._UNRESTRICTED_PROVENANCE_STATE_KEY, None)
+
+        copied = super().model_copy(update=sanitized_update, deep=deep)
+        trusted_id = self._get_provider_hydrated_unrestricted_id()
+        if (
+            not copied.unrestrictedLocations
+            or copied.id != self.id
+            or trusted_id != self.id
+        ):
+            trusted_id = None
+        copied._set_provider_hydrated_unrestricted_id(trusted_id)
+        return copied
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._UNRESTRICTED_MARKER_NAMES:
+            raise ValueError("unrestricted placement provenance is internal")
+        previous_id = self.id if name == "id" else None
+        super().__setattr__(name, value)
+        if name == "id" and previous_id != value:
+            self._set_provider_hydrated_unrestricted_id(None)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = super().__getstate__()
+        for marker_name in self._UNRESTRICTED_MARKER_NAMES:
+            state.pop(marker_name, None)
+
+        trusted_id = self._get_provider_hydrated_unrestricted_id()
+        if self.unrestrictedLocations and self.id is not None and trusted_id == self.id:
+            state[self._UNRESTRICTED_PROVENANCE_STATE_KEY] = trusted_id
+        return state
+
+    def __reduce_ex__(self, protocol: int):
+        reduced = super().__reduce_ex__(protocol)
+        constructor, args, *parts = reduced
+        state = parts[0] if parts else None
+        list_items = parts[1] if len(parts) > 1 else None
+        dict_items = parts[2] if len(parts) > 2 else None
+        trusted_id = state.get(self._UNRESTRICTED_PROVENANCE_STATE_KEY)
+        return (
+            constructor,
+            args,
+            state,
+            list_items,
+            dict_items,
+            partial(ServerlessResource._setstate_from_pickle, trusted_id=trusted_id),
+        )
+
+    @staticmethod
+    def _setstate_from_pickle(
+        resource,
+        state: Dict[str, Any],
+        *,
+        trusted_id: Optional[str],
+    ) -> None:
+        resource._restore_serialized_state(state, trusted_id=trusted_id)
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self._restore_serialized_state(state, trusted_id=None)
+
+    def _restore_serialized_state(
+        self,
+        state: Dict[str, Any],
+        *,
+        trusted_id: Optional[str],
+    ) -> None:
+        restored_state = dict(state)
+        for marker_name in self._UNRESTRICTED_MARKER_NAMES:
+            restored_state.pop(marker_name, None)
+        state_provenance = restored_state.pop(
+            self._UNRESTRICTED_PROVENANCE_STATE_KEY, None
+        )
+
+        super().__setstate__(restored_state)
+        private_values = {
+            name: private_attr.get_default()
+            for name, private_attr in self.__private_attributes__.items()
+        }
+        object.__setattr__(self, "__pydantic_private__", private_values)
+        object.__setattr__(self, "__pydantic_extra__", None)
+        object.__setattr__(
+            self,
+            "__pydantic_fields_set__",
+            set(restored_state).intersection(self.__class__.model_fields),
+        )
+        self._set_provider_hydrated_unrestricted_id(None)
+
+        if trusted_id is None:
+            if self.unrestrictedLocations and self.id is not None:
+                if state_provenance is None:
+                    message = "missing trusted provider provenance"
+                elif (
+                    not isinstance(state_provenance, str) or state_provenance != self.id
+                ):
+                    message = "mismatched provider provenance"
+                else:
+                    message = "untrusted provider provenance"
+                raise ValueError(f"unrestricted endpoint state has {message}")
+            return
+        if (
+            not isinstance(trusted_id, str)
+            or state_provenance != trusted_id
+            or not self.unrestrictedLocations
+            or self.id is None
+            or trusted_id != self.id
+        ):
+            raise ValueError(
+                "unrestricted endpoint state has mismatched provider provenance"
+            )
+
+        self._set_provider_hydrated_unrestricted_id(trusted_id)
+        self._validate_unrestricted_placement()
+
+    def _get_provider_hydrated_unrestricted_id(self) -> Optional[str]:
+        private_values = getattr(self, "__pydantic_private__", None)
+        if not isinstance(private_values, dict):
+            return None
+        trusted_id = private_values.get("_provider_hydrated_unrestricted_id")
+        return trusted_id if isinstance(trusted_id, str) else None
+
+    def _set_provider_hydrated_unrestricted_id(self, trusted_id: Optional[str]) -> None:
+        private_values = getattr(self, "__pydantic_private__", None)
+        if not isinstance(private_values, dict):
+            private_values = {}
+            object.__setattr__(self, "__pydantic_private__", private_values)
+        private_values["_provider_hydrated_unrestricted_id"] = trusted_id
+        self.__dict__.pop("_provider_hydrated_unrestricted_id", None)
+
+    def _validate_unrestricted_placement(self) -> None:
+        if not self.unrestrictedLocations:
+            return
+        if not self.SUPPORTS_UNRESTRICTED_LOCATIONS or self._has_cpu_instances():
+            raise ValueError("unrestrictedLocations is only valid for GPU endpoints")
+        trusted_id = self._get_provider_hydrated_unrestricted_id()
+        if self.id is not None and trusted_id != self.id:
+            raise ValueError(
+                "unrestrictedLocations is only valid for newly provisioned endpoints "
+                "or the exact provider-hydrated endpoint"
+            )
+        if self.datacenter is not None or self.locations is not None:
+            raise ValueError(
+                "datacenter and locations cannot be set when unrestrictedLocations is enabled"
+            )
+        if (
+            self.networkVolume is not None
+            or self.networkVolumes
+            or self.networkVolumeId is not None
+            or getattr(self, "_deployed_volume_ids", [])
+        ):
+            raise ValueError(
+                "network volumes cannot be set when unrestrictedLocations is enabled"
+            )
+
     @model_validator(mode="after")
     def sync_input_fields(self):
         """Sync between temporary inputs and exported fields.
@@ -570,19 +763,22 @@ class ServerlessResource(DeployableResource):
                 self.name = self.name[:-3]
             self.flashBootType = "FLASHBOOT"
 
-        # sync datacenter list to locations field for API
-        env_locations = os.getenv("RUNPOD_DEFAULT_LOCATIONS")
-        env_datacenter = os.getenv("RUNPOD_DEFAULT_DATACENTER")
-        if env_locations:
-            self.locations = env_locations
-        elif not self.locations:
-            if env_datacenter:
-                try:
-                    self.locations = DataCenter(env_datacenter).value
-                except ValueError:
-                    self.locations = env_datacenter
-            elif self.datacenter:
-                self.locations = ",".join(dc.value for dc in self.datacenter)
+        self._validate_unrestricted_placement()
+
+        if not self.unrestrictedLocations:
+            # sync datacenter list to locations field for API
+            env_locations = os.getenv("RUNPOD_DEFAULT_LOCATIONS")
+            env_datacenter = os.getenv("RUNPOD_DEFAULT_DATACENTER")
+            if env_locations:
+                self.locations = env_locations
+            elif not self.locations:
+                if env_datacenter:
+                    try:
+                        self.locations = DataCenter(env_datacenter).value
+                    except ValueError:
+                        self.locations = env_datacenter
+                elif self.datacenter:
+                    self.locations = ",".join(dc.value for dc in self.datacenter)
 
         # validate that all network volume DCs are within the endpoint's datacenter list
         all_volumes = self.networkVolumes or (
@@ -742,15 +938,39 @@ class ServerlessResource(DeployableResource):
             if self.env or not has_explicit_template_env:
                 self.template.env = KeyValuePair.from_dict(self.env)
 
-    async def _sync_graphql_object_with_inputs(
-        self, returned_endpoint: "ServerlessResource"
-    ):
-        for _input_field in self._input_only or set():
-            if getattr(self, _input_field) is not None:
-                # sync input only fields stripped from gql request back to endpoint
-                setattr(returned_endpoint, _input_field, getattr(self, _input_field))
+    def _hydrate_graphql_result(
+        self,
+        result: Dict[str, Any],
+        *,
+        expected_id: Optional[str] = None,
+    ) -> "ServerlessResource":
+        """Build a deployed model while preserving validated input-only intent."""
+        if self.unrestrictedLocations and (
+            result.get("networkVolumeId") or result.get("networkVolumeIds")
+        ):
+            raise ValueError(
+                "network volumes cannot be set when unrestrictedLocations is enabled"
+            )
 
-        return returned_endpoint
+        hydrated_data = dict(result)
+        for input_field in self._input_only or set():
+            if input_field == "id":
+                continue
+            value = getattr(self, input_field)
+            if value is not None:
+                hydrated_data[input_field] = value
+
+        hydrated_id = hydrated_data.pop("id", None)
+        if expected_id is not None and hydrated_id != expected_id:
+            raise ValueError(
+                "provider returned an endpoint id that does not match the updated endpoint"
+            )
+        hydrated = self.__class__.model_validate(hydrated_data)
+        hydrated.id = hydrated_id
+        if hydrated.unrestrictedLocations and hydrated_id is not None:
+            hydrated._set_provider_hydrated_unrestricted_id(hydrated_id)
+        hydrated._validate_unrestricted_placement()
+        return hydrated
 
     def _sync_input_fields_gpu(self):
         if self.gpuIds:
@@ -783,6 +1003,13 @@ class ServerlessResource(DeployableResource):
         Sets networkVolumeId (singular) for backward compat with the first volume.
         Populates _deployed_volume_ids for multi-volume API payloads.
         """
+        if self.unrestrictedLocations and (
+            self.networkVolumeId or self._deployed_volume_ids
+        ):
+            raise ValueError(
+                "network volumes cannot be set when unrestrictedLocations is enabled"
+            )
+
         self._deployed_volume_ids = []
 
         if self.networkVolumeId:
@@ -808,6 +1035,7 @@ class ServerlessResource(DeployableResource):
         """
         Checks if the serverless resource is deployed and available.
         """
+        self._validate_unrestricted_placement()
         try:
             if not self.id:
                 return False
@@ -1077,6 +1305,8 @@ class ServerlessResource(DeployableResource):
         Returns a DeployableResource object.
         """
         try:
+            self._validate_unrestricted_placement()
+
             # If the resource is already deployed, return it
             if await self.is_deployed():
                 log.debug(f"{self} exists")
@@ -1097,9 +1327,11 @@ class ServerlessResource(DeployableResource):
 
                 result = await client.save_endpoint(payload)
 
-            if endpoint := self.__class__(**result):
-                endpoint = await self._sync_graphql_object_with_inputs(endpoint)
+            if endpoint := self._hydrate_graphql_result(result):
                 self.id = endpoint.id
+                self._set_provider_hydrated_unrestricted_id(
+                    endpoint._get_provider_hydrated_unrestricted_id()
+                )
                 self.templateId = endpoint.templateId
                 self.template = (
                     None  # templateId takes precedence; clear to avoid conflict
@@ -1132,6 +1364,14 @@ class ServerlessResource(DeployableResource):
         """
         if not self.id:
             raise ValueError("Cannot update: endpoint not deployed")
+        self._validate_unrestricted_placement()
+        if new_config.unrestrictedLocations:
+            if not self.unrestrictedLocations:
+                raise ValueError(
+                    "Cannot update a restricted endpoint to unrestricted placement; "
+                    "provision a new endpoint instead"
+                )
+            self._validate_unrestricted_placement()
 
         try:
             resolved_template_id = self.templateId or new_config.templateId
@@ -1140,6 +1380,7 @@ class ServerlessResource(DeployableResource):
                 log.debug("updating endpoint '%s' (ID: %s)", self.name, self.id)
 
             # Ensure network volumes are deployed if specified
+            new_config._validate_unrestricted_placement()
             await new_config._ensure_network_volume_deployed()
 
             async with RunpodGraphQLClient() as client:
@@ -1242,16 +1483,16 @@ class ServerlessResource(DeployableResource):
                             "be resolved; skipping separate saveTemplate call"
                         )
 
-            if updated := self.__class__(**result):
-                if not updated.templateId:
-                    updated.templateId = (
-                        resolved_template_id or self.templateId or new_config.templateId
-                    )
-                # Keep local input-only state on the hydrated model. The GraphQL
-                # response does not include many user-provided fields (for example
-                # env, networkVolume, datacenter), and dropping them causes
-                # repeated false drift on subsequent deploys.
-                updated = await new_config._sync_graphql_object_with_inputs(updated)
+            hydrated_result = dict(result)
+            hydrated_result["templateId"] = (
+                result.get("templateId")
+                or resolved_template_id
+                or self.templateId
+                or new_config.templateId
+            )
+            if updated := new_config._hydrate_graphql_result(
+                hydrated_result, expected_id=self.id
+            ):
                 log.debug(
                     f"Successfully updated endpoint '{self.name}' (ID: {self.id})"
                 )
@@ -1323,6 +1564,11 @@ class ServerlessResource(DeployableResource):
         # hydrate the id onto the resource so it's usable when this is called directly
         # on a config
         self.id = resource.id
+        if isinstance(resource, ServerlessResource):
+            self._set_provider_hydrated_unrestricted_id(
+                resource._get_provider_hydrated_unrestricted_id()
+            )
+        self._validate_unrestricted_placement()
         self.templateId = getattr(resource, "templateId", None)
         return self
 

--- a/src/runpod_flash/core/resources/serverless_cpu.py
+++ b/src/runpod_flash/core/resources/serverless_cpu.py
@@ -6,7 +6,7 @@ This module contains all CPU-related serverless functionality, separate from GPU
 
 import hashlib
 import json
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 from pydantic import field_serializer, model_validator
 
@@ -22,6 +22,7 @@ from .template import KeyValuePair, PodTemplate
 class CpuEndpointMixin:
     """Mixin class that provides CPU-specific functionality for serverless endpoints."""
 
+    SUPPORTS_UNRESTRICTED_LOCATIONS: ClassVar[bool] = False
     instanceIds: Optional[List[CpuInstanceType]]
 
     def _is_cpu_endpoint(self) -> bool:
@@ -128,6 +129,7 @@ class CpuServerlessEndpoint(CpuEndpointMixin, ServerlessEndpoint):
         "networkVolume",
         "networkVolumes",
         "python_version",
+        "unrestrictedLocations",
     }
 
     # Override GPU field from parent to None for CPU endpoints

--- a/src/runpod_flash/endpoint.py
+++ b/src/runpod_flash/endpoint.py
@@ -417,6 +417,7 @@ class Endpoint:
         template: Optional[PodTemplate] = None,
         min_cuda_version: Optional[CudaVersion | str] = CudaVersion.V12_8,
         max_concurrency: int = 1,
+        unrestricted_locations: bool = False,
     ):
         if gpu is not None and cpu is not None:
             raise ValueError(
@@ -429,6 +430,23 @@ class Endpoint:
             )
         if name is None and id is None and image is not None:
             raise ValueError("name or id is required when image= is set.")
+        if unrestricted_locations:
+            if id is not None:
+                raise ValueError(
+                    "unrestricted_locations is only valid for newly provisioned endpoints."
+                )
+            if cpu is not None:
+                raise ValueError(
+                    "unrestricted_locations is only valid for gpu endpoints."
+                )
+            if datacenter is not None:
+                raise ValueError(
+                    "datacenter cannot be set when unrestricted_locations is enabled."
+                )
+            if volume is not None:
+                raise ValueError(
+                    "network volume cannot be set when unrestricted_locations is enabled."
+                )
 
         if max_concurrency < 1:
             raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
@@ -463,6 +481,7 @@ class Endpoint:
         self.scaler_value = scaler_value
         self.template = template
         self.min_cuda_version = min_cuda_version
+        self.unrestricted_locations = unrestricted_locations
 
         # if no gpu or cpu specified, default to gpu any. image= still provisions
         # a new endpoint, so only id-only clients (connecting to an existing
@@ -473,7 +492,12 @@ class Endpoint:
         # make sure default datacenters are set when provisioning a new endpoint.
         # image= still provisions, so only id-only clients skip this. not CPU
         # though, that gets pinned to specific datacenters.
-        if not self._is_cpu and self.id is None and not self.datacenter:
+        if (
+            not self._is_cpu
+            and self.id is None
+            and not self.datacenter
+            and not self.unrestricted_locations
+        ):
             self.datacenter = DataCenter.all()
 
         # lb routes registered via .get()/.post()/etc (decorator mode only)
@@ -569,6 +593,9 @@ class Endpoint:
             ),
             "scalerValue": self.scaler_value,
         }
+
+        if self.unrestricted_locations:
+            kwargs["unrestrictedLocations"] = True
 
         if self.template is not None:
             # serialize to dict to avoid pydantic model identity issues

--- a/tests/unit/resources/test_resource_manager.py
+++ b/tests/unit/resources/test_resource_manager.py
@@ -1,11 +1,16 @@
 """Unit tests for ResourceManager."""
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from runpod_flash.core.resources.resource_manager import ResourceManager
 from runpod_flash.core.utils.singleton import SingletonMixin
-from runpod_flash.core.resources.serverless import ServerlessResource
+from runpod_flash.core.resources.serverless import (
+    ServerlessEndpoint,
+    ServerlessResource,
+)
 from runpod_flash.core.exceptions import RunpodAPIKeyError
 
 
@@ -16,6 +21,7 @@ class TestResourceManager:
     def reset_singleton(self):
         """Reset singleton state before each test."""
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False
@@ -23,6 +29,7 @@ class TestResourceManager:
         yield
         # Cleanup after test
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False
@@ -347,6 +354,176 @@ class TestResourceManager:
         mock_add.assert_called_once_with(resource_key, updated)
         assert result is updated
 
+    @pytest.mark.asyncio
+    async def test_rejects_restricted_to_unrestricted_update_before_api_mutation(
+        self, mock_resource_file
+    ):
+        manager = ResourceManager()
+        existing = ServerlessEndpoint(
+            name="restricted-endpoint",
+            id="endpoint-existing",
+            imageName="example/image:v1",
+            flashboot=False,
+            locations="US-TX-3",
+        )
+        new_config = ServerlessEndpoint(
+            name="restricted-endpoint",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        resource_key = new_config.get_resource_key()
+        manager._resources[resource_key] = existing
+        manager._resource_configs[resource_key] = existing.config_hash
+
+        with (
+            patch.object(
+                ServerlessEndpoint,
+                "is_deployed",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+            ) as client_class,
+            patch.object(manager, "_add_resource") as add_resource,
+        ):
+            with pytest.raises(ValueError, match="restricted endpoint"):
+                await manager.get_or_deploy_resource(new_config)
+
+        client_class.assert_not_called()
+        add_resource.assert_not_called()
+        assert manager._resources[resource_key] is existing
+        assert existing.unrestrictedLocations is None
+        assert existing.locations == "US-TX-3"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"}, clear=True)
+    async def test_reuses_cached_hydrated_unrestricted_resource(
+        self, mock_resource_file
+    ):
+        manager = ResourceManager()
+        config = ServerlessEndpoint(
+            name="cached-unrestricted",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        hydrated = config._hydrate_graphql_result(
+            {
+                "id": "endpoint-cached",
+                "name": "cached-unrestricted",
+                "templateId": "template-cached",
+                "gpuIds": config.gpuIds,
+            }
+        )
+        resource_key = config.get_resource_key()
+        manager._resources[resource_key] = hydrated
+        manager._resource_configs[resource_key] = config.config_hash
+
+        result = await manager.get_or_deploy_resource(config)
+
+        assert result is hydrated
+        assert result._get_provider_hydrated_unrestricted_id() == result.id
+
+    @pytest.mark.asyncio
+    async def test_rejects_cached_hydrated_id_substitution_before_reuse(
+        self, mock_resource_file
+    ):
+        manager = ResourceManager()
+        config = ServerlessEndpoint(
+            name="cached-substituted-id",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        hydrated = config._hydrate_graphql_result(
+            {
+                "id": "trusted-id",
+                "name": "cached-substituted-id",
+                "templateId": "template-cached",
+                "gpuIds": config.gpuIds,
+            }
+        )
+        hydrated.id = "substituted-id"
+        resource_key = config.get_resource_key()
+        manager._resources[resource_key] = hydrated
+        manager._resource_configs[resource_key] = config.config_hash
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+                await manager.get_or_deploy_resource(config)
+
+        client_class.assert_not_called()
+        assert manager._resources[resource_key] is hydrated
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"}, clear=True)
+    async def test_persisted_unrestricted_resource_reloads_and_reuses(
+        self, mock_resource_file
+    ):
+        config = ServerlessEndpoint(
+            name="persisted-unrestricted",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        hydrated = config._hydrate_graphql_result(
+            {
+                "id": "endpoint-persisted",
+                "name": "persisted-unrestricted",
+                "templateId": "template-persisted",
+                "gpuIds": config.gpuIds,
+            }
+        )
+        resource_key = config.get_resource_key()
+
+        with patch(
+            "runpod_flash.core.resources.resource_manager.FLASH_STATE_DIR",
+            mock_resource_file.parent,
+        ):
+            manager = ResourceManager()
+            manager._add_resource(resource_key, hydrated)
+
+            ResourceManager._resources = {}
+            ResourceManager._resource_configs = {}
+            ResourceManager._deployment_locks = {}
+            ResourceManager._resources_initialized = False
+            ResourceManager._lock_initialized = False
+            SingletonMixin._instances.pop(ResourceManager, None)
+
+            reloaded_manager = ResourceManager()
+            result = await reloaded_manager.get_or_deploy_resource(config)
+
+        assert result.id == "endpoint-persisted"
+        assert result._get_provider_hydrated_unrestricted_id() == result.id
+        result._validate_unrestricted_placement()
+
+    @pytest.mark.asyncio
+    async def test_rejects_mutated_unrestricted_id_before_caching(
+        self, mock_resource_file
+    ):
+        manager = ResourceManager()
+        config = ServerlessEndpoint(
+            name="mutated-unrestricted-id",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        resource_key = config.get_resource_key()
+        config.id = "endpoint-existing"
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            with pytest.raises(ValueError, match="newly provisioned"):
+                await manager.get_or_deploy_resource(config)
+
+        client_class.assert_not_called()
+        assert resource_key not in manager._resources
+        assert resource_key not in manager._resource_configs
+
 
 class TestConfigHashStability:
     """Test that config_hash is stable and excludes dynamic fields like env."""
@@ -355,11 +532,13 @@ class TestConfigHashStability:
     def reset_singleton(self):
         """Reset singleton state before each test."""
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False
         yield
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False
@@ -469,11 +648,13 @@ class TestCpuEndpointConfigHash:
     def reset_singleton(self):
         """Reset singleton state before each test."""
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False
         yield
         ResourceManager._resources = {}
+        ResourceManager._resource_configs = {}
         ResourceManager._deployment_locks = {}
         ResourceManager._resources_initialized = False
         ResourceManager._lock_initialized = False

--- a/tests/unit/resources/test_serverless_unrestricted_locations.py
+++ b/tests/unit/resources/test_serverless_unrestricted_locations.py
@@ -1,0 +1,588 @@
+"""tests for unrestricted placement in serverless resources."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import cloudpickle
+import pytest
+
+from runpod_flash.core.resources.base import BaseResource
+from runpod_flash.core.resources.cpu import CpuInstanceType
+from runpod_flash.core.resources.datacenter import DataCenter
+from runpod_flash.core.resources.live_serverless import (
+    CpuLiveLoadBalancer,
+    CpuLiveServerless,
+)
+from runpod_flash.core.resources.load_balancer_sls_resource import (
+    CpuLoadBalancerSlsResource,
+    LoadBalancerSlsResource,
+)
+from runpod_flash.core.resources.network_volume import NetworkVolume
+from runpod_flash.core.resources.serverless import (
+    ServerlessEndpoint,
+    ServerlessResource,
+)
+from runpod_flash.core.resources.serverless_cpu import CpuServerlessEndpoint
+
+
+def _hydrated_unrestricted(name: str = "hydrated-id-bound") -> ServerlessEndpoint:
+    config = ServerlessEndpoint(
+        name=name,
+        imageName="example/image:v1",
+        flashboot=False,
+        unrestrictedLocations=True,
+    )
+    return config._hydrate_graphql_result(
+        {
+            "id": "trusted-id",
+            "name": name,
+            "templateId": "template-id",
+            "gpuIds": config.gpuIds,
+        }
+    )
+
+
+class TestServerlessUnrestrictedLocations:
+    def test_unrestricted_intent_changes_resource_identity(self):
+        default = ServerlessEndpoint(
+            name="identity",
+            imageName="example/image:v1",
+            flashboot=False,
+        )
+        unrestricted = ServerlessEndpoint(
+            name="identity",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+
+        assert default.resource_id != unrestricted.resource_id
+        assert default.config_hash != unrestricted.config_hash
+
+    def test_unrestricted_flag_is_input_only_and_hashed(self):
+        input_only = ServerlessResource._input_only
+        hashed_fields = ServerlessResource._hashed_fields
+        if hasattr(input_only, "default"):
+            input_only = input_only.default
+        if hasattr(hashed_fields, "default"):
+            hashed_fields = hashed_fields.default
+
+        assert "unrestrictedLocations" in input_only
+        assert "unrestrictedLocations" in hashed_fields
+
+    def test_unrestricted_resource_rejects_datacenter(self):
+        with pytest.raises(ValueError, match="datacenter"):
+            ServerlessEndpoint(
+                name="invalid",
+                imageName="example/image:v1",
+                datacenter=DataCenter.EU_RO_1,
+                unrestrictedLocations=True,
+            )
+
+    @pytest.mark.parametrize(
+        "volume_kwargs",
+        [
+            {"networkVolume": NetworkVolume(name="volume", size=10)},
+            {"networkVolumes": [NetworkVolume(name="volume-list", size=10)]},
+            {"networkVolumeId": "volume-123"},
+        ],
+    )
+    def test_unrestricted_resource_rejects_network_volume(self, volume_kwargs):
+        with pytest.raises(ValueError, match="network volumes"):
+            ServerlessEndpoint(
+                name="invalid-volume",
+                imageName="example/image:v1",
+                unrestrictedLocations=True,
+                **volume_kwargs,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_resource_rejects_deployed_volume_ids(self):
+        resource = ServerlessEndpoint(
+            name="invalid-deployed-volume",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+        resource._deployed_volume_ids = ["volume-123"]
+
+        with pytest.raises(ValueError, match="network volumes"):
+            await resource._ensure_network_volume_deployed()
+
+    @pytest.mark.parametrize(
+        "resource_class",
+        [
+            CpuServerlessEndpoint,
+            CpuLoadBalancerSlsResource,
+            CpuLiveServerless,
+            CpuLiveLoadBalancer,
+        ],
+    )
+    @pytest.mark.parametrize("instance_ids", [None, []])
+    def test_unrestricted_resource_rejects_cpu_class_capability(
+        self, resource_class, instance_ids
+    ):
+        with pytest.raises(ValueError, match="GPU endpoints"):
+            resource_class(
+                name="invalid-cpu",
+                imageName="example/image:v1",
+                instanceIds=instance_ids,
+                unrestrictedLocations=True,
+            )
+
+    @pytest.mark.parametrize(
+        "resource_class",
+        [ServerlessEndpoint, LoadBalancerSlsResource],
+    )
+    def test_generic_gpu_resource_rejects_effective_cpu_shape(self, resource_class):
+        with pytest.raises(ValueError, match="GPU endpoints"):
+            resource_class(
+                name="invalid-generic-cpu",
+                imageName="example/image:v1",
+                instanceIds=[CpuInstanceType.CPU3G_2_8],
+                unrestrictedLocations=True,
+            )
+
+    @pytest.mark.parametrize(
+        "resource_class",
+        [ServerlessEndpoint, LoadBalancerSlsResource],
+    )
+    def test_generic_gpu_hydration_rejects_provider_cpu_shape(self, resource_class):
+        resource = resource_class(
+            name="invalid-hydrated-cpu",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+
+        with pytest.raises(ValueError, match="GPU endpoints"):
+            resource._hydrate_graphql_result(
+                {
+                    "id": "endpoint-cpu",
+                    "name": "invalid-hydrated-cpu",
+                    "templateId": "template-cpu",
+                    "instanceIds": [CpuInstanceType.CPU3G_2_8.value],
+                }
+            )
+
+    @pytest.mark.parametrize(
+        "marker_name",
+        [
+            "providerHydratedUnrestricted",
+            "provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted_id",
+        ],
+    )
+    def test_public_hydration_marker_input_cannot_authorize_id(self, marker_name):
+        payload = {
+            "name": "marker-reset",
+            "id": "endpoint-existing",
+            "imageName": "example/image:v1",
+            "unrestrictedLocations": True,
+            marker_name: "endpoint-existing",
+        }
+
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            ServerlessEndpoint(**payload)
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            ServerlessEndpoint.model_validate(payload)
+
+    def test_public_hydration_marker_is_not_a_model_field(self):
+        assert "providerHydratedUnrestricted" not in ServerlessEndpoint.model_fields
+
+    @pytest.mark.parametrize(
+        "resource_class",
+        [ServerlessEndpoint, LoadBalancerSlsResource],
+    )
+    def test_public_resource_rejects_id_with_unrestricted_placement(
+        self, resource_class
+    ):
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            resource_class(
+                name="invalid-existing",
+                id="endpoint-existing",
+                imageName="example/image:v1",
+                unrestrictedLocations=True,
+                providerHydratedUnrestricted=True,
+            )
+
+    @pytest.mark.parametrize(
+        "marker_name",
+        [
+            "providerHydratedUnrestricted",
+            "provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted_id",
+        ],
+    )
+    def test_model_construct_marker_cannot_authorize_id(self, marker_name):
+        resource = ServerlessEndpoint.model_construct(
+            name="constructed-marker",
+            id="endpoint-existing",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+            **{marker_name: "endpoint-existing"},
+        )
+
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            resource._validate_unrestricted_placement()
+
+    def test_direct_marker_assignment_is_rejected(self):
+        resource = ServerlessEndpoint(
+            name="invalid-public-marker",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+
+        with pytest.raises(ValueError, match="provenance is internal"):
+            resource.providerHydratedUnrestricted = True
+        with pytest.raises(ValueError, match="provenance is internal"):
+            resource._provider_hydrated_unrestricted_id = "endpoint-existing"
+
+        resource.id = "endpoint-existing"
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            resource._validate_unrestricted_placement()
+
+    def test_hydrated_id_substitution_rejected_before_validate(self):
+        resource = _hydrated_unrestricted()
+
+        resource.id = "substituted-id"
+
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            resource._validate_unrestricted_placement()
+
+    def test_model_copy_preserves_provenance_only_without_id_change(self):
+        resource = _hydrated_unrestricted()
+
+        copied = resource.model_copy()
+        copied._validate_unrestricted_placement()
+        assert copied.id == "trusted-id"
+        assert copied._get_provider_hydrated_unrestricted_id() == "trusted-id"
+
+        forged = resource.model_copy(
+            update={
+                "id": "restricted-id",
+                "providerHydratedUnrestricted": True,
+                "_provider_hydrated_unrestricted_id": "restricted-id",
+            }
+        )
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            forged._validate_unrestricted_placement()
+
+    @pytest.mark.asyncio
+    async def test_hydrated_id_substitution_rejected_before_is_deployed(self):
+        resource = _hydrated_unrestricted("substituted-health")
+        resource.id = "substituted-id"
+
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            await resource.is_deployed()
+
+    @pytest.mark.asyncio
+    async def test_hydrated_id_substitution_rejected_before_do_deploy(self):
+        resource = _hydrated_unrestricted("substituted-deploy")
+        resource.id = "substituted-id"
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+                await resource._do_deploy()
+
+        client_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hydrated_id_substitution_rejected_before_update_api_mutation(self):
+        resource = _hydrated_unrestricted("substituted-update")
+        resource.id = "substituted-id"
+        new_config = ServerlessEndpoint(
+            name="substituted-update",
+            imageName="example/image:v2",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+                await resource.update(new_config)
+
+        client_class.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "marker_name",
+        [
+            "providerHydratedUnrestricted",
+            "provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted",
+            "_provider_hydrated_unrestricted_id",
+        ],
+    )
+    def test_direct_setstate_old_marker_cannot_authorize_id(self, marker_name):
+        state = ServerlessEndpoint(
+            name="restored-old-marker",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        ).__getstate__()
+        state["id"] = "restricted-id"
+        state[marker_name] = "restricted-id"
+        restored = object.__new__(ServerlessEndpoint)
+
+        with pytest.raises(ValueError, match="missing trusted provider provenance"):
+            restored.__setstate__(state)
+        assert restored._get_provider_hydrated_unrestricted_id() is None
+
+    def test_direct_setstate_matching_provenance_key_cannot_authorize_id(self):
+        state = ServerlessEndpoint(
+            name="restored-matching-key",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        ).__getstate__()
+        state["id"] = "restricted-id"
+        state[ServerlessResource._UNRESTRICTED_PROVENANCE_STATE_KEY] = "restricted-id"
+        restored = object.__new__(ServerlessEndpoint)
+
+        with pytest.raises(ValueError, match="untrusted provider provenance"):
+            restored.__setstate__(state)
+        assert restored._get_provider_hydrated_unrestricted_id() is None
+
+    def test_cloudpickle_round_trip_preserves_exact_id_provenance(self):
+        resource = _hydrated_unrestricted("pickle-round-trip")
+
+        restored = cloudpickle.loads(cloudpickle.dumps(resource))
+
+        assert restored.id == "trusted-id"
+        assert restored._get_provider_hydrated_unrestricted_id() == "trusted-id"
+        restored._validate_unrestricted_placement()
+
+    def test_setstate_rejects_mismatched_exact_id_provenance(self):
+        resource = _hydrated_unrestricted("pickle-tampered")
+        state = resource.__getstate__()
+        state["id"] = "substituted-id"
+        restored = object.__new__(ServerlessEndpoint)
+
+        with pytest.raises(ValueError, match="mismatched provider provenance"):
+            restored.__setstate__(state)
+        assert restored._get_provider_hydrated_unrestricted_id() is None
+
+    def test_base_setstate_public_marker_cannot_authorize_id(self):
+        state = ServerlessEndpoint(
+            name="base-setstate-old-marker",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        ).__getstate__()
+        state["id"] = "restricted-id"
+        state["providerHydratedUnrestricted"] = True
+        restored = object.__new__(ServerlessEndpoint)
+
+        BaseResource.__setstate__(restored, state)
+
+        assert restored._get_provider_hydrated_unrestricted_id() is None
+        with pytest.raises(ValueError, match="exact provider-hydrated endpoint"):
+            restored._validate_unrestricted_placement()
+
+    @pytest.mark.asyncio
+    async def test_post_construction_id_rejected_before_is_deployed_early_return(self):
+        resource = ServerlessEndpoint(
+            name="invalid-mutated-id-health",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+        resource.id = "endpoint-existing"
+
+        with pytest.raises(ValueError, match="newly provisioned"):
+            await resource.is_deployed()
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"}, clear=True)
+    async def test_post_construction_id_rejected_before_deploy_early_return(self):
+        resource = ServerlessEndpoint(
+            name="invalid-mutated-id",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+        resource.id = "endpoint-existing"
+
+        with pytest.raises(ValueError, match="newly provisioned"):
+            await resource._do_deploy()
+
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("networkVolumeId", "late-volume-id"),
+            ("networkVolume", NetworkVolume(name="late-volume", size=10)),
+            (
+                "networkVolumes",
+                [NetworkVolume(name="late-volume-list", size=10)],
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_post_construction_volume_rejected_before_remote_deploy(
+        self, field_name, value
+    ):
+        resource = ServerlessEndpoint(
+            name="invalid-mutated-volume",
+            imageName="example/image:v1",
+            unrestrictedLocations=True,
+        )
+        setattr(resource, field_name, value)
+
+        with (
+            patch.object(
+                NetworkVolume,
+                "deploy",
+                new=AsyncMock(),
+            ) as deploy_volume,
+            patch(
+                "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+            ) as client_class,
+        ):
+            with pytest.raises(ValueError, match="network volumes"):
+                await resource._do_deploy()
+
+        deploy_volume.assert_not_awaited()
+        client_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hydration_and_update_preserve_unrestricted_intent(self):
+        initial = ServerlessEndpoint(
+            name="hydrated",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        deploy_client = AsyncMock()
+        deploy_client.save_endpoint.return_value = {
+            "id": "endpoint-hydrated",
+            "name": "hydrated",
+            "templateId": "template-hydrated",
+            "gpuIds": initial.gpuIds,
+            "allowedCudaVersions": "",
+        }
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            client_class.return_value.__aenter__.return_value = deploy_client
+            client_class.return_value.__aexit__.return_value = None
+            hydrated = await initial._do_deploy()
+
+        assert hydrated.unrestrictedLocations is True
+        assert hydrated.datacenter is None
+        assert hydrated.locations is None
+        assert hydrated._get_provider_hydrated_unrestricted_id() == hydrated.id
+
+        persisted = cloudpickle.loads(cloudpickle.dumps(hydrated))
+        assert persisted.id == "endpoint-hydrated"
+        assert persisted.unrestrictedLocations is True
+        assert persisted.locations is None
+        assert persisted._get_provider_hydrated_unrestricted_id() == persisted.id
+        persisted._validate_unrestricted_placement()
+
+        updated_config = ServerlessEndpoint(
+            name="hydrated",
+            templateId="template-hydrated",
+            flashboot=False,
+            unrestrictedLocations=True,
+            workersMax=5,
+        )
+        update_client = AsyncMock()
+        update_client.save_endpoint.return_value = {
+            "id": "endpoint-hydrated",
+            "name": "hydrated",
+            "templateId": "template-hydrated",
+            "gpuIds": updated_config.gpuIds,
+            "allowedCudaVersions": "",
+            "workersMax": 5,
+        }
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            client_class.return_value.__aenter__.return_value = update_client
+            client_class.return_value.__aexit__.return_value = None
+            updated = await hydrated.update(updated_config)
+
+        payload = update_client.save_endpoint.call_args.args[0]
+        assert payload["id"] == "endpoint-hydrated"
+        assert "locations" not in payload
+        assert "unrestrictedLocations" not in payload
+        assert updated.unrestrictedLocations is True
+        assert updated.datacenter is None
+        assert updated.locations is None
+
+    @pytest.mark.asyncio
+    async def test_hydration_rejects_backend_restricted_state(self):
+        initial = ServerlessEndpoint(
+            name="hydrated-backend-locations",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+        mock_client = AsyncMock()
+        mock_client.save_endpoint.return_value = {
+            "id": "endpoint-backend-locations",
+            "name": "hydrated-backend-locations",
+            "templateId": "template-backend-locations",
+            "gpuIds": initial.gpuIds,
+            "allowedCudaVersions": "",
+            "locations": "US-TX-3",
+        }
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            client_class.return_value.__aenter__.return_value = mock_client
+            client_class.return_value.__aexit__.return_value = None
+            with pytest.raises(ValueError, match="locations cannot be set"):
+                await initial._do_deploy()
+
+    @pytest.mark.parametrize(
+        "provider_volume_field,provider_volume_value",
+        [
+            ("networkVolumeId", "provider-volume"),
+            (
+                "networkVolumeIds",
+                [{"networkVolumeId": "provider-volume"}],
+            ),
+        ],
+    )
+    def test_hydration_rejects_provider_network_volumes(
+        self, provider_volume_field, provider_volume_value
+    ):
+        initial = ServerlessEndpoint(
+            name="hydrated-provider-volume",
+            imageName="example/image:v1",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+
+        with pytest.raises(ValueError, match="network volumes"):
+            initial._hydrate_graphql_result(
+                {
+                    "id": "endpoint-provider-volume",
+                    "name": "hydrated-provider-volume",
+                    "templateId": "template-provider-volume",
+                    "gpuIds": initial.gpuIds,
+                    provider_volume_field: provider_volume_value,
+                }
+            )
+
+    def test_update_rejects_provider_id_substitution(self):
+        existing = _hydrated_unrestricted("provider-id-substitution")
+        new_config = ServerlessEndpoint(
+            name="provider-id-substitution",
+            imageName="example/image:v2",
+            flashboot=False,
+            unrestrictedLocations=True,
+        )
+
+        with pytest.raises(ValueError, match="does not match the updated endpoint"):
+            new_config._hydrate_graphql_result(
+                {
+                    "id": "substituted-id",
+                    "name": "provider-id-substitution",
+                    "gpuIds": new_config.gpuIds,
+                },
+                expected_id=existing.id,
+            )

--- a/tests/unit/test_endpoint_unrestricted_locations.py
+++ b/tests/unit/test_endpoint_unrestricted_locations.py
@@ -1,0 +1,166 @@
+"""tests for unrestricted serverless endpoint placement."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from runpod_flash.core.resources.cpu import CpuInstanceType
+from runpod_flash.core.resources.datacenter import DataCenter
+from runpod_flash.core.resources.gpu import GpuGroup
+from runpod_flash.core.resources.load_balancer_sls_resource import (
+    LoadBalancerSlsResource,
+)
+from runpod_flash.core.resources.network_volume import NetworkVolume
+from runpod_flash.core.resources.serverless import CudaVersion, ServerlessScalerType
+from runpod_flash.core.resources.template import PodTemplate
+from runpod_flash.endpoint import Endpoint
+
+
+class TestEndpointUnrestrictedLocations:
+    def test_default_gpu_endpoint_keeps_all_datacenters(self):
+        endpoint = Endpoint(name="default-placement", gpu=GpuGroup.ADA_24)
+
+        config = endpoint._build_resource_config()
+
+        assert endpoint.datacenter == DataCenter.all()
+        assert config.datacenter == DataCenter.all()
+        assert config.locations
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "false"}, clear=True)
+    async def test_unrestricted_endpoint_deploys_without_location_payload(self):
+        endpoint = Endpoint(
+            name="unrestricted",
+            image="example/image:v1",
+            gpu=GpuGroup.ADA_24,
+            gpu_count=2,
+            workers=(1, 3),
+            idle_timeout=90,
+            execution_timeout_ms=12_000,
+            scaler_type=ServerlessScalerType.REQUEST_COUNT,
+            scaler_value=7,
+            min_cuda_version=CudaVersion.V12_4,
+            unrestricted_locations=True,
+        )
+        config = endpoint._build_resource_config()
+        mock_client = AsyncMock()
+        mock_client.save_endpoint.return_value = {
+            "id": "endpoint-123",
+            "name": "unrestricted",
+            "templateId": "template-123",
+            "gpuIds": config.gpuIds,
+            "gpuCount": 2,
+            "allowedCudaVersions": "",
+        }
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            client_class.return_value.__aenter__.return_value = mock_client
+            client_class.return_value.__aexit__.return_value = None
+            deployed = await config._do_deploy()
+
+        payload = mock_client.save_endpoint.call_args.args[0]
+        assert config.datacenter is None
+        assert config.locations is None
+        assert deployed.unrestrictedLocations is True
+        assert deployed.datacenter is None
+        assert deployed.locations is None
+        assert "locations" not in payload
+        assert "unrestrictedLocations" not in payload
+        assert payload["gpuIds"] == config.gpuIds
+        assert payload["gpuCount"] == 2
+        assert payload["template"]["imageName"] == "example/image:v1"
+        assert payload["minCudaVersion"] == "12.4"
+        assert payload["workersMin"] == 1
+        assert payload["workersMax"] == 3
+        assert payload["scalerType"] == "REQUEST_COUNT"
+        assert payload["scalerValue"] == 7
+        assert payload["idleTimeout"] == 90
+        assert payload["executionTimeoutMs"] == 12_000
+
+    @pytest.mark.asyncio
+    @patch.dict(
+        os.environ,
+        {
+            "FLASH_IS_LIVE_PROVISIONING": "false",
+            "RUNPOD_DEFAULT_LOCATIONS": "US-TX-3",
+            "RUNPOD_DEFAULT_DATACENTER": "EU-RO-1",
+        },
+        clear=True,
+    )
+    async def test_unrestricted_endpoint_ignores_ambient_location_defaults(self):
+        endpoint = Endpoint(
+            name="unrestricted-env",
+            image="example/image:v1",
+            unrestricted_locations=True,
+        )
+        config = endpoint._build_resource_config()
+        mock_client = AsyncMock()
+        mock_client.save_endpoint.return_value = {
+            "id": "endpoint-env",
+            "name": "unrestricted-env",
+            "templateId": "template-env",
+            "gpuIds": config.gpuIds,
+            "allowedCudaVersions": "",
+        }
+
+        with patch(
+            "runpod_flash.core.resources.serverless.RunpodGraphQLClient"
+        ) as client_class:
+            client_class.return_value.__aenter__.return_value = mock_client
+            client_class.return_value.__aexit__.return_value = None
+            await config._do_deploy()
+
+        payload = mock_client.save_endpoint.call_args.args[0]
+        assert config.datacenter is None
+        assert config.locations is None
+        assert "locations" not in payload
+        assert "unrestrictedLocations" not in payload
+
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "false"}, clear=True)
+    def test_unrestricted_load_balanced_endpoint_uses_same_placement_contract(self):
+        endpoint = Endpoint(
+            name="unrestricted-lb",
+            template=PodTemplate(imageName="example/image:v1"),
+            unrestricted_locations=True,
+        )
+
+        @endpoint.get("/health")
+        async def health():
+            return {"ok": True}
+
+        config = endpoint._build_resource_config()
+
+        assert isinstance(config, LoadBalancerSlsResource)
+        assert config.unrestrictedLocations is True
+        assert config.datacenter is None
+        assert config.locations is None
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"cpu": CpuInstanceType.CPU3G_2_8}, "gpu endpoints"),
+            ({"id": "endpoint-123"}, "newly provisioned"),
+            ({"datacenter": DataCenter.EU_RO_1}, "datacenter"),
+            ({"volume": NetworkVolume(name="volume", size=10)}, "network volume"),
+            (
+                {
+                    "volume": [
+                        NetworkVolume(
+                            name="volume-list", size=10, dataCenterId=DataCenter.EU_RO_1
+                        )
+                    ]
+                },
+                "network volume",
+            ),
+        ],
+    )
+    def test_unrestricted_endpoint_rejects_incompatible_options(self, kwargs, message):
+        with pytest.raises(ValueError, match=message):
+            Endpoint(
+                name="invalid-unrestricted",
+                unrestricted_locations=True,
+                **kwargs,
+            )


### PR DESCRIPTION
## Summary

- add an explicit `Endpoint(unrestricted_locations=True)` option for newly provisioned GPU serverless endpoints
- omit `locations` from the final RunPod payload even when ambient location defaults are set
- reject CPU, existing-ID, explicit-data-center, and network-volume combinations before API mutation
- preserve exact unrestricted placement intent through resource identity, provider hydration, updates, persistence, and resource-manager reuse

## Why

RunPod treats an omitted or null `locations` field as provider-wide placement. The SDK currently replaces an omitted data center with `DataCenter.all()`, then serializes that storage-capable subset into `locations`. Callers therefore cannot request genuinely provider-wide serverless placement through the public SDK.

The new option is input-only and hashed. It never appears in the GraphQL payload, and default endpoint behavior remains unchanged.

## Validation

Exact final diff:

- `87 passed` in the focused placement and state-integrity regressions
- `495 passed` in the affected endpoint, serverless, CPU, load-balancer, resource-manager, identity, and regression suites
- exploit probes reject endpoint-ID substitution, Pydantic copy/construct marker forgery, and stale-state marker restoration
- `make format-check` passed
- `make lint` passed
- `uv build` produced the source distribution and wheel
- `git diff --check` passed

Repository-wide baseline comparison before the final authorization hardening:

- full `make quality-check`: `2665 passed, 1 skipped, 1 xfailed, 2 failed`
- full-suite coverage: `85.86%`
- both failures reproduce unchanged on untouched upstream `main`

## Baseline failures

The two unrelated failures are:

- `tests/unit/cli/test_main.py::TestVersionFlag::test_version_long_flag`
- `tests/unit/cli/test_main.py::TestVersionFlag::test_version_short_flag`

Both expect the unstyled substring `Runpod Flash CLI v1.4.1`, while Rich emits ANSI styling inside the version. The same failures reproduce on untouched upstream `main`.
