### PR TITLE
fix(credentials): read runpodctl top-level apikey as fallback

### DIFF
--- a/src/runpod_flash/core/credentials.py
+++ b/src/runpod_flash/core/credentials.py
@@ -51,10 +51,35 @@ def get_api_key() -> Optional[str]:
         creds = get_credentials()
     except Exception:
         log.debug("Failed to read credentials file", exc_info=True)
-        return None
-    if creds and isinstance(creds.get("api_key"), str) and creds["api_key"].strip():
-        return creds["api_key"]
+    else:
+        if creds and isinstance(creds.get("api_key"), str) and creds["api_key"].strip():
+            return creds["api_key"]
 
+    return _get_runpodctl_api_key()
+
+
+def _get_runpodctl_api_key() -> Optional[str]:
+    """Read runpodctl's top-level `apikey` from the config file.
+
+    runpodctl writes a top-level `apikey` (and `apiurl`) key with no profile
+    table, which runpod-python's profile-based lookup cannot see. Fall back to
+    parsing the file directly so a config written by runpodctl authenticates
+    flash. Returns None when the file or key is missing, malformed, or blank.
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+
+    try:
+        with get_credentials_path().open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, ValueError):
+        log.debug("Failed to read credentials file for runpodctl apikey", exc_info=True)
+        return None
+    api_key = data.get("apikey")
+    if isinstance(api_key, str) and api_key.strip():
+        return api_key
     return None
 
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -11,6 +11,8 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+import pytest
+
 from runpod_flash.core.credentials import (
     get_api_key,
     get_credentials_path,
@@ -56,6 +58,37 @@ class TestGetApiKey:
         isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
         isolate_credentials_file.write_text("not valid toml {{{{")
         assert get_api_key() is None
+
+    def test_falls_back_to_runpodctl_top_level_apikey(self, isolate_credentials_file):
+        """A config.toml written by runpodctl (top-level `apikey`, no [default]
+        profile) must authenticate flash."""
+        isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
+        isolate_credentials_file.write_text(
+            "apikey = 'rpa_runpodctl_key'\napiurl = 'https://api.runpod.io/graphql'\n"
+        )
+        assert get_api_key() == "rpa_runpodctl_key"
+
+    def test_default_profile_takes_precedence_over_runpodctl_apikey(
+        self, isolate_credentials_file
+    ):
+        isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
+        isolate_credentials_file.write_text(
+            "apikey = 'rpa_runpodctl_key'\n[default]\napi_key = 'flash-key'\n"
+        )
+        assert get_api_key() == "flash-key"
+
+    def test_ignores_blank_runpodctl_apikey(self, isolate_credentials_file):
+        isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
+        isolate_credentials_file.write_text("apikey = '  '\n")
+        assert get_api_key() is None
+
+    def test_no_file_still_raises_runpod_api_key_error(self, isolate_credentials_file):
+        """With no credentials file at all, validation must raise."""
+        from runpod_flash.core.exceptions import RunpodAPIKeyError
+        from runpod_flash.core.validation import validate_api_key
+
+        with pytest.raises(RunpodAPIKeyError):
+            validate_api_key()
 
 
 class TestSaveApiKey:


### PR DESCRIPTION
flash could not authenticate from a `~/.runpod/config.toml` written by runpodctl. runpodctl writes a top-level `apikey` key with no `[default]` profile table, but `get_api_key()` only consulted runpod-python's profile-based `get_credentials()`, which returns no key in that case — so flash reported "No RunPod API key found" about a file it read without error that contained a valid key. This adds a file-based fallback: when the profile lookup finds no usable `api_key`, flash parses the config file directly (via `tomllib`) and returns the top-level `apikey` (`apiurl` stays ignored). Precedence is unchanged: env var > `[default].api_key` > runpodctl top-level `apikey`.

Fixes runpod/flash#363
Internal: CON-1228

## What changed
- `src/runpod_flash/core/credentials.py`: `get_api_key()` now falls back to a new `_get_runpodctl_api_key()` helper that parses the credential file with `tomllib` and returns the top-level `apikey` when the `[default]` profile has no usable key. Missing file, malformed TOML, and blank/non-string keys all yield `None` as before.
- `tests/unit/test_credentials.py`: new tests — runpodctl-format config (top-level `apikey` only) yields the key; `[default]` profile takes precedence over the top-level key; blank top-level `apikey` is ignored; no credentials file still raises `RunpodAPIKeyError` via `validate_api_key()`.

## How verified
- `pytest tests/unit/test_credentials.py tests/unit/test_credential_migration.py` — 33 passed.
- `pytest` on all credential/login/API-key-related unit files (7 files) — 104 passed.
- `ruff check` and `ruff format --check` on both touched files — clean.
- `mypy` full run: no net-new errors vs `main` (261 pre-existing errors; the 2 attributed to `credentials.py` are pre-existing patterns — `tomllib` stub and `Any` return — identical before and after).

The write path (`save_api_key`) already preserved runpodctl's top-level keys; this PR only fixes the read path.