### PR TITLE
fix: run each matrix leg on its own Python version, and stop a leaked test thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,17 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     timeout-minutes: 15
 
+    # Without this the matrix is decorative. `make dev` runs a bare `uv sync`,
+    # and uv resolves its interpreter from .python-version (pinned to 3.11)
+    # rather than from whatever actions/setup-python just installed -- so every
+    # leg built a 3.11 venv and all four ran the same interpreter. UV_PYTHON
+    # takes precedence over the pin file, which restores real version coverage.
+    #
+    # Set at job level, not on the install step: `make ci-quality-github` runs
+    # `uv run pytest`, which resolves the interpreter again.
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/tests/unit/cli/commands/test_run_server_helpers.py
+++ b/tests/unit/cli/commands/test_run_server_helpers.py
@@ -336,12 +336,34 @@ class TestCallWithBodyEmptyInputValidation:
         assert result == {"echo": "hello"}
         func.assert_called_once_with(msg="hello")
 
+    # These two wrap the mock in a real async def instead of passing the mock
+    # straight to call_with_body.
+    #
+    # call_with_body -> _map_body_to_params calls inspect.signature(func), and
+    # signature() of a Mock is version-dependent: on 3.10 it raises
+    # `TypeError: 'Mock' object is not subscriptable` (Mock auto-creates a
+    # __signature__ child, which inspect then tries to use), while on 3.11+ it
+    # reports (*args, **kwargs). Passing spec= does not help -- the failure is
+    # in signature(), not in spec resolution.
+    #
+    # call_with_body catches Exception and converts it into a 500 JSONResponse,
+    # so on 3.10 these failed as `assert <JSONResponse object> == {'ok': True}`,
+    # with the real TypeError visible only inside the response body.
+    #
+    # The wrapper declares (*args, **kwargs), the same signature 3.11+ inferred
+    # from the Mock, so both branches of _map_body_to_params behave exactly as
+    # before -- and delegating to the mock keeps the call assertions.
+
     @pytest.mark.asyncio
     async def test_allows_plain_dict_body(self):
         """Non-empty plain dict passes through unchanged (no model_fields_set)."""
         body = {"key": "value"}
 
-        func = AsyncMock(return_value={"ok": True})
+        mock = AsyncMock(return_value={"ok": True})
+
+        async def func(*args, **kwargs):
+            return await mock(*args, **kwargs)
+
         result = await call_with_body(func, body)
 
         assert result == {"ok": True}
@@ -354,8 +376,12 @@ class TestCallWithBodyEmptyInputValidation:
         """
         body = {}
 
-        func = AsyncMock(return_value={"ok": True})
+        mock = AsyncMock(return_value={"ok": True})
+
+        async def func(*args, **kwargs):
+            return await mock(*args, **kwargs)
+
         result = await call_with_body(func, body)
 
         assert result == {"ok": True}
-        func.assert_called_once_with()
+        mock.assert_called_once_with()

--- a/tests/unit/core/resources/test_resource_manager_extended.py
+++ b/tests/unit/core/resources/test_resource_manager_extended.py
@@ -9,6 +9,17 @@ from runpod_flash.core.resources.resource_manager import (
 )
 
 
+class _LegacyResource:
+    """Minimal picklable stand-in for a resource in the pre-1.12 state file.
+
+    Module-level, not defined inside a test: cloudpickle serialises a class
+    defined in a function body by value, which is the thing being avoided here.
+    """
+
+    def __init__(self, config_hash: str):
+        self.config_hash = config_hash
+
+
 @pytest.fixture(autouse=True)
 def reset_manager(isolate_resource_state_file, reset_singletons):
     """Reset singleton and state file between tests."""
@@ -56,7 +67,13 @@ class TestLoadResources:
         state_file = tmp_path / ".runpod" / "resources.pkl"
         state_file.parent.mkdir(parents=True)
 
-        resources = {"key1": MagicMock(config_hash="hash1")}
+        # A plain object rather than MagicMock: whether cloudpickle can pickle a
+        # Mock is version-dependent, and on 3.10 this failed with
+        # "Could not pickle object as excessively deep recursion required".
+        # Only .config_hash is read here (via _refresh_config_hashes), and the
+        # absence of get_resource_key is what keeps the legacy key un-migrated,
+        # which is exactly what this test is asserting.
+        resources = {"key1": _LegacyResource("hash1")}
         with open(state_file, "wb") as f:
             cloudpickle.dump(resources, f)
 

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -195,19 +195,44 @@ class TestDeploymentOrchestrator:
             assert results[0].duration >= 0.09
 
     def test_deploy_all_background(self, mock_resources):
-        """Test background deployment doesn't block."""
+        """Test background deployment starts a daemon thread without blocking."""
         orchestrator = DeploymentOrchestrator()
 
-        with patch.object(
-            orchestrator.manager, "get_or_deploy_resource", new_callable=AsyncMock
-        ) as mock_deploy:
+        # threading.Thread is stubbed rather than left to run for real.
+        #
+        # deploy_all_background() starts a daemon thread and returns
+        # immediately, so a real thread outlives this test: the patch below
+        # would be lifted while the thread was still starting, and the thread
+        # would then call the *unpatched* manager and register these
+        # MagicMock(spec=ServerlessResource) objects into the ResourceManager
+        # singleton -- during whichever unrelated test happened to be running
+        # at that moment. ResourceManager._save_resources() cloudpickles its
+        # whole state on every registration, and a MagicMock cannot be pickled,
+        # so an arbitrary later test died with
+        #
+        #   _pickle.PicklingError: args[0] from __newobj__ args has the wrong class
+        #
+        # Which test got hit depended on thread scheduling and on xdist's
+        # worker assignment, which is what made it flaky rather than simply
+        # broken. Stubbing the thread keeps the assertion this test actually
+        # makes -- that the call is non-blocking and spawns a daemon thread --
+        # and lets nothing escape the test.
+        with (
+            patch("runpod_flash.core.deployment.threading.Thread") as mock_thread_cls,
+            patch.object(
+                orchestrator.manager, "get_or_deploy_resource", new_callable=AsyncMock
+            ) as mock_deploy,
+        ):
             mock_deploy.side_effect = mock_resources
 
             # Should not block
             orchestrator.deploy_all_background(mock_resources)
 
-            # Background thread should be started
-            # (not much we can test here without waiting for thread)
+            # A daemon thread was started, and nothing ran inline.
+            mock_thread_cls.assert_called_once()
+            assert mock_thread_cls.call_args.kwargs["daemon"] is True
+            mock_thread_cls.return_value.start.assert_called_once()
+            mock_deploy.assert_not_called()
 
     def test_deploy_all_background_empty_list(self):
         """Test background deployment with empty list."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version < '3.13'",
@@ -824,7 +824,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2669,6 +2669,7 @@ dependencies = [
     { name = "rich" },
     { name = "runpod" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -2698,6 +2699,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "runpod", git = "https://github.com/runpod/runpod-python?rev=main" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. The Python version matrix was decorative

`quality-gates` declares `['3.10', '3.11', '3.12', '3.13']`, but **every leg ran Python 3.11**. `make dev` runs a bare `uv sync`, and uv resolves its interpreter from `.python-version` (pinned to `3.11`) rather than from the one `actions/setup-python` just installed.

Confirmed across four CI runs on three unrelated branches, the oldest from 2026-08-10 — every leg reports `Using CPython 3.11.x` and builds `.venv/lib/python3.11`:

| Run | Branch | Leg that failed | Interpreter |
|---|---|---|---|
| 31410374670 | `deanq/sls-python-parity-by-default` | Quality Gates (**3.10**) | Python 3.11.15 |
| 32861648254 | `fix/367-app-delete-removes-endpoint` | Quality Gates (**3.12**) | Python 3.11.16 |
| 32869479106 | `fix/365-deploy-empty-resources` | Quality Gates (**3.12**) | Python 3.11.16 |
| 33012747552 | `Henrik/ci-coverage-artifact` | Quality Gates (**3.13**) | Python 3.11.16 |

Fix: `UV_PYTHON: ${{ matrix.python-version }}`, which takes precedence over the pin file. Set at **job** level rather than on the install step, because `make ci-quality-github` runs `uv run pytest`, which resolves the interpreter again.

### `uv.lock` was stale, and 3.13 could not resolve without it

Re-locked in the same commit. It was wrong in two ways:

* `requires-python = ">=3.10, <3.13"` while `pyproject.toml` says `>=3.10,<3.14` — the lock never covered 3.13 at all
* `tomlkit>=0.13.0` is declared in `pyproject.toml` but was missing from the `runpod-flash` dependency and `requires-dist` lists

```
uv lock --check   (previous lock)  -> exit 1, "needs to be updated"
uv lock --check   (this lock)      -> passes on 3.10, 3.11, 3.12, 3.13
```

CI never caught the drift: `pre-check` uses `--frozen`, which does not verify freshness, and `make dev` uses plain `uv sync`, which silently re-resolves on the runner.

## 2. `test_deploy_all_background` leaked a thread into other tests

This was the cause of a flaky failure that landed on an **unrelated** test, usually:

```
FAILED tests/unit/test_regressions.py::TestREG008NonInteractiveEnvDelete::test_undeploy_resource_force_remove_no_tty
_pickle.PicklingError: args[0] from __newobj__ args has the wrong class
```

`deploy_all_background()` starts a daemon thread and returns immediately, and the test never joined it. The `patch.object(..., "get_or_deploy_resource")` context was lifted while the thread was still starting, so the thread ran against the **unpatched** manager and registered the fixture's `MagicMock(spec=ServerlessResource)` objects into the `ResourceManager` singleton — during whichever unrelated test happened to be running at that moment.

`ResourceManager._save_resources()` cloudpickles its entire state on every registration, and a `MagicMock` cannot be pickled: `obj.__class__` is the spec'd class while `type(obj)` is `MagicMock`, exactly the mismatch `pickle.save_reduce` rejects. The mock arrived as a dict **key**, via `_migrate_to_name_based_keys()` calling `resource.get_resource_key()` on it — hence the key rendering as `<MagicMock name='mock.get_resource_key()'>`.

Because it depended on thread scheduling *and* on xdist's dynamic worker assignment, the victim, the worker and the matrix leg all varied per run — see the table above (legs 3.10/3.12/3.13, workers gw0/gw2/gw3). Forcing everything into one process reproduced it every time; `-n 4` reproduced it in **0 of 6** runs.

`threading.Thread` is now stubbed, which keeps what the test actually asserts — the call is non-blocking and spawns a daemon thread — and lets nothing escape. The test previously asserted nothing at all; its own comment said *"not much we can test here without waiting for thread"*.

## Verification

| Check | Result |
|---|---|
| Full suite, single-process, 3.11 (the reproducer) | 2680 passed, **0 PicklingError** |
| Full suite, single-process, **real Python 3.13** | 2680 passed, **0 PicklingError**, no 3.13-specific failures |
| Serial pass (`-m serial`) | 53 passed, 1 skipped |
| `ruff format --check` + `ruff check`, 260 tracked files | clean |

The same single-process run reproduced the failure before the change, so this is a before/after comparison rather than an absence of evidence.

## Not addressed here

Two deeper faults behind this class of bug, both wider changes than a flake fix:

* `ResourceManager._resources` / `_resource_configs` are class variables, so instance *mutation* writes through to global state — while `_load_resources()` uses *assignment*, which shadows them with instance attributes. The manager silently switches between class-level and instance-level state depending on whether the state file existed.
* `conftest.worker_flash_dir` is `scope="session"`, so every test in a worker shares one `resources.pkl`, and `reset_singletons` forces a reload from it on every test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
