### PR TITLE
fix: send workersStandby for scale-to-zero + read runpodctl config

### DIFF
--- a/src/runpod_flash/core/credentials.py
+++ b/src/runpod_flash/core/credentials.py
@@ -38,7 +38,10 @@ def get_credentials_path() -> Path:
 
 
 def get_api_key() -> Optional[str]:
-    """Get API key with priority: env var > credentials file.
+    """Get API key with priority: env var > [default].api_key > top-level apikey.
+
+    The last fallback covers credentials written by runpodctl, which stores
+    a top-level ``apikey`` key instead of a ``[default]`` profile section.
 
     Returns:
         API key string, or None if not found.
@@ -51,9 +54,26 @@ def get_api_key() -> Optional[str]:
         creds = get_credentials()
     except Exception:
         log.debug("Failed to read credentials file", exc_info=True)
-        return None
+        creds = None
     if creds and isinstance(creds.get("api_key"), str) and creds["api_key"].strip():
         return creds["api_key"]
+
+    # Fall back to runpodctl-style top-level "apikey"
+    try:
+        path = get_credentials_path()
+        if path.exists():
+            with path.open("rb") as f:
+                try:
+                    import tomllib
+                except ImportError:
+                    import tomli as tomllib
+                data = tomllib.load(f)
+            top_key = data.get("apikey")
+            if isinstance(top_key, str) and top_key.strip():
+                log.debug("Using runpodctl-style top-level 'apikey' from %s", path)
+                return top_key
+    except Exception:
+        log.debug("Failed to check for runpodctl-style apikey", exc_info=True)
 
     return None
 

--- a/src/runpod_flash/core/resources/serverless.py
+++ b/src/runpod_flash/core/resources/serverless.py
@@ -286,6 +286,7 @@ class ServerlessResource(DeployableResource):
     type: Optional[ServerlessType] = ServerlessType.QB
     workersMax: Optional[int] = DEFAULT_WORKERS_MAX
     workersMin: Optional[int] = DEFAULT_WORKERS_MIN
+    workersStandby: Optional[int] = None
     workersPFBTarget: Optional[int] = 0
 
     # === Private Attributes ===

--- a/src/runpod_flash/endpoint.py
+++ b/src/runpod_flash/endpoint.py
@@ -558,6 +558,7 @@ class Endpoint:
             "name": self.name,
             "workersMin": self._workers_min,
             "workersMax": self._workers_max,
+            "workersStandby": self._workers_min,
             "idleTimeout": self.idle_timeout,
             "executionTimeoutMs": self.execution_timeout_ms,
             "flashboot": self.flashboot,

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -57,6 +57,28 @@ class TestGetApiKey:
         isolate_credentials_file.write_text("not valid toml {{{{")
         assert get_api_key() is None
 
+    def test_falls_back_to_runpodctl_top_level_apikey(self, isolate_credentials_file):
+        """When only runpodctl-style top-level 'apikey' exists (no [default]
+        section), get_api_key() should find it. Fixes #363."""
+        isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
+        isolate_credentials_file.write_text(
+            "apikey = 'rpa_runpodctl_key'\n"
+            "apiurl = 'https://api.runpod.io/graphql'\n"
+        )
+        assert get_api_key() == "rpa_runpodctl_key"
+
+    def test_default_section_takes_precedence_over_top_level(self, isolate_credentials_file):
+        """When both [default].api_key and top-level apikey exist, the
+        [default] section should win."""
+        isolate_credentials_file.parent.mkdir(parents=True, exist_ok=True)
+        isolate_credentials_file.write_text(
+            "apikey = 'rpa_runpodctl_key'\n"
+            "\n"
+            "[default]\n"
+            'api_key = "flash-key"\n'
+        )
+        assert get_api_key() == "flash-key"
+
 
 class TestSaveApiKey:
     def test_creates_file_and_directories(self, isolate_credentials_file):


### PR DESCRIPTION
## Summary

Two fixes in one branch (separate commits):

### 1. Scale-to-zero broken by missing `workersStandby` (Fixes #364)

When deploying with `workers=(0, N)`, Flash sends `workersMin: 0` but never sends `workersStandby`. RunPod's API defaults `workersStandby` to 1, so a warm worker stays up 24/7 even though the user asked for scale-to-zero.

**Fix:** Add `workersStandby` field to `ServerlessResource` and set it to `workersMin` in the deploy payload. `workers=(0, 4)` now sends `workersStandby: 0` — true scale-to-zero.

### 2. Flash can't read runpodctl's config.toml (Fixes #363)

`runpodctl` writes credentials as a top-level `apikey` field. Flash only looks for `[default].api_key`. Users who set up `runpodctl` first get "please run flash login" despite valid credentials existing in the same file.

**Fix:** Add a fallback in `get_api_key()` to check the top-level `apikey` when no `[default]` section is found. `[default].api_key` still wins when both exist.

## Test plan

- [x] All 25 credential tests pass (23 existing + 2 new)
- [x] New test: runpodctl-only config file → `get_api_key()` returns the key
- [x] New test: both formats present → `[default].api_key` takes precedence

Closes #364
Closes #363