### PR TITLE
fix: remove torchvision from SIZE_PROHIBITIVE_PACKAGES

### DIFF
--- a/src/runpod_flash/cli/commands/build.py
+++ b/src/runpod_flash/cli/commands/build.py
@@ -168,7 +168,6 @@ PIP_MODULE = "pip"
 SIZE_PROHIBITIVE_PACKAGES: frozenset[str] = frozenset(
     {
         "torch",  # ~500 MB
-        "torchvision",  # ~50 MB, requires torch
         "torchaudio",  # ~30 MB, requires torch
         "triton",  # ~150 MB, CUDA compiler
     }


### PR DESCRIPTION
## Summary

Remove `torchvision` from the `SIZE_PROHIBITIVE_PACKAGES` blacklist.

Fixes #353

## What was wrong

`torchvision` was unconditionally excluded from dependency installation because it was assumed to be:
1. Present in GPU base images — **it is not** (only `torch` is)
2. 50 MB — **it is 7.3 MB** now

When a user explicitly requests `dependencies=["torchvision"]`, Flash silently strips it. The deploy succeeds, but the app crashes at runtime with `ImportError: No module named torchvision`.

## What changed

One line removed from the `SIZE_PROHIBITIVE_PACKAGES` frozenset in `build.py`. `torch` (500 MB), `torchaudio` (30 MB), and `triton` (150 MB) remain blacklisted as they are genuinely large and present in base images.

## Test plan

- [x] Verified `torchvision` is not in RunPod GPU base images (confirmed by issue reporter)
- [x] Current wheel size is 7.3 MB (well below the threshold for size-based exclusion)