### PR TITLE
fix: warn and exit early when deploy has no resources

### DIFF
--- a/src/runpod_flash/cli/commands/deploy.py
+++ b/src/runpod_flash/cli/commands/deploy.py
@@ -10,7 +10,7 @@ from typing import Any
 import typer
 from rich.console import Console
 
-from runpod_flash.cli.utils.formatting import print_error
+from runpod_flash.cli.utils.formatting import print_error, print_warning
 from runpod_flash.core.exceptions import RunpodAPIKeyError
 from runpod_flash.core.resources.app import FlashApp
 
@@ -220,6 +220,15 @@ async def _resolve_and_deploy(
     app, resolved_env_name = await _resolve_environment(app_name, env_name)
 
     local_manifest = validate_local_manifest()
+
+    if not local_manifest.get("resources"):
+        print_warning(
+            console,
+            "No deployable resources found in the manifest. "
+            "Client-mode endpoints (image=...) provision on first call, "
+            "not at deploy time. Nothing to upload.",
+        )
+        return
 
     from rich.progress import (
         BarColumn,


### PR DESCRIPTION
## Summary

Detect empty `resources` in the manifest before uploading and print a clear warning instead of a misleading "✓ deployed to production".

Fixes #365

## What was wrong

Client-mode endpoints (`image=...`) are excluded from the manifest's `resources` dict because they don't define serverless handlers. `flash deploy` would:

1. Upload the build archive (wasting time and bandwidth)
2. Create/update the environment
3. Print "✓ deployed to production" and exit 0

No serverless endpoint was actually provisioned. The user sees success but has nothing deployed. The endpoint only gets created lazily on first `endpoint()` call.

## What changed

Added an early check in `_resolve_and_deploy()` after `validate_local_manifest()`:
- If `resources` is empty, print a warning explaining that client-mode endpoints provision on first call
- Return immediately without uploading or printing false success

This is the minimal fix. A more comprehensive approach (eagerly provisioning client-mode endpoints at deploy time) would require design discussion around the lazy-loading architecture.

## Test plan

- [x] Client-mode apps with empty resources now get a clear warning instead of fake success
- [x] Normal apps with resources continue to deploy as before (the check only triggers on empty dict)